### PR TITLE
MLIBZ-307 Sync failed in version 1.1.13

### DIFF
--- a/src/core/persistence/sync.js
+++ b/src/core/persistence/sync.js
@@ -189,7 +189,7 @@ var Sync = /** @lends Sync */{
     return Sync._read(collection, documents, options).then(function(response) {
       // Step 2: categorize the documents in the collection.
       var promises = identifiers.map(function(id) {
-        var document = documents[id];
+        var document = documents[id] || {};
         var metadata = {
           id: id,
           timestamp: document.timestamp,


### PR DESCRIPTION
When upgrading to any version later then 1.1.13 of the JavaScript library, syncing would fail. This was due to the change in how metadata was stored in the sync table. The library assumed that metadata was always defined where as prior to 1.1.13 it could have been null. Because of the metadata being null, the library was trying to access properties on the value null which resulted in an exception being thrown and the sync process to fail.
