### PR TITLE
MLIBZ-288 User-friendly handling of 4xx/5xx responses

### DIFF
--- a/src/internals/persistence/net/node-http.js
+++ b/src/internals/persistence/net/node-http.js
@@ -137,7 +137,7 @@ var NodeHttp = {
           var promise;
           var originalRequest = options._originalRequest;
 
-          if (401 === response.statusCode && options.attemptMICRefresh) {
+          if (401 === status && options.attemptMICRefresh) {
             promise = MIC.refresh(options);
           }
           else {
@@ -152,7 +152,14 @@ var NodeHttp = {
           }).then(function(response) {
             deferred.resolve(response);
           }, function() {
-            deferred.reject(responseData.toString() || null);
+            var error = responseData.toString() || null;
+
+            if (Array.isArray(error)) {
+              error = new Kinvey.Error('Received an array as a response with a status code of ' + status + '. A JSON ' +
+                                       'object is expected as a response to requests that result in an error status code.');
+            }
+
+            deferred.reject(error);
           });
         }
       });

--- a/src/internals/persistence/net/xhr.js
+++ b/src/internals/persistence/net/xhr.js
@@ -145,7 +145,7 @@ var Xhr = {
         var promise;
         var originalRequest = options._originalRequest;
 
-        if (401 === request.status && options.attemptMICRefresh) {
+        if (401 === status && options.attemptMICRefresh) {
           promise = MIC.refresh(options);
         }
         else {
@@ -183,7 +183,14 @@ var Xhr = {
             }
           }
           else {// Return the error.
-            deferred.reject(response || type || null);
+            var error = response || type || null;
+
+            if (Array.isArray(error)) {
+              error = new Kinvey.Error('Received an array as a response with a status code of ' + status + '. A JSON ' +
+                                       'object is expected as a response to requests that result in an error status code.');
+            }
+
+            deferred.reject(error);
           }
         });
       }

--- a/src/shims/angular/persistence/net.js
+++ b/src/shims/angular/persistence/net.js
@@ -159,7 +159,14 @@ var AngularHTTP = {
         // Resend original request
         return Kinvey.Persistence.Net._request(originalRequest, options);
       }, function() {
-        return Kinvey.Defer.reject(response.data || null);
+        var error = response.data || null;
+
+        if (Array.isArray(error)) {
+          error = new Kinvey.Error('Received an array as a response with a status code of ' + response.status + '. A JSON ' +
+                                   'object is expected as a response to requests that result in an error status code.');
+        }
+
+        return Kinvey.Defer.reject(error);
       });
     });
   }

--- a/src/shims/backbone/persistence/net.js
+++ b/src/shims/backbone/persistence/net.js
@@ -125,7 +125,7 @@ var BackboneAjax = {
         var promise;
         var originalRequest = options._originalRequest;
 
-        if (401 === request.status && options.attemptMICRefresh) {
+        if (401 === status && options.attemptMICRefresh) {
           promise = MIC.refresh(options);
         }
         else {
@@ -140,7 +140,14 @@ var BackboneAjax = {
         }).then(function(response) {
           deferred.resolve(response);
         }, function() {
-          deferred.reject(request.responseText || textStatus || null);
+          var error = request.responseText || textStatus || null;
+
+          if (Array.isArray(error)) {
+            error = new Kinvey.Error('Received an array as a response with a status code of ' + status + '. A JSON ' +
+                                     'object is expected as a response to requests that result in an error status code.');
+          }
+
+          deferred.reject(error);
         });
       }
     };

--- a/src/shims/titanium/persistence/net.js
+++ b/src/shims/titanium/persistence/net.js
@@ -142,8 +142,9 @@ var TiHttp = {
       else { // Failure.
         var promise;
         var originalRequest = options._originalRequest;
+        var error = this.responseText || e.type || null;
 
-        if (401 === this.status && options.attemptMICRefresh) {
+        if (401 === status && options.attemptMICRefresh) {
           promise = MIC.refresh(options);
         }
         else {
@@ -158,7 +159,12 @@ var TiHttp = {
         }).then(function(response) {
           deferred.resolve(response);
         }, function() {
-          deferred.reject(this.responseText || e.type || null);
+          if (Array.isArray(error)) {
+            error = new Kinvey.Error('Received an array as a response with a status code of ' + status + '. A JSON ' +
+                                     'object is expected as a response to requests that result in an error status code.');
+          }
+
+          deferred.reject(error);
         });
       }
     };


### PR DESCRIPTION
Checks responses to requests that result in an error status code to ensure an object is received and not an array. If an array is received, an error message is returned informing the user a JSON object was expected. 
