### PR TITLE
MLIBZ-341: Doesn't validate input in User.login method

### DIFF
--- a/src/core/user.js
+++ b/src/core/user.js
@@ -98,8 +98,9 @@ Kinvey.User = /** @lends Kinvey.User */{
     options = options || {};
 
     // Validate arguments.
-    if(null == usernameOrData.username || null == usernameOrData.password) {
-      error = new Kinvey.Error('Argument must contain: username and password');
+    if((null == usernameOrData.username || null == usernameOrData.password)
+       && null == usernameOrData._socialIdentity) {
+      error = new Kinvey.Error('Username and/or password missing. Please provide both a username and password to login.');
       return wrapCallbacks(Kinvey.Defer.reject(error), options);
     }
 


### PR DESCRIPTION
I updated the logic in the `if` statement to reject the call to `User.login` if either the `usernameOrData.username` or `usernameOrData.password` values are `null` or `undefined` and `usernameOrData._socialIdentity` is not `null`. 

I also update the error message to be more user friendly. 

`usernameOrData._socialIdentity` is a special property used to login users when they connect with third party social OAuth providers. If it is not `null` or `undefined` it prevent the function from being rejected since it is all that is needed to login without requiring a `username` or `password` to be defined.
