### PR TITLE
MLIBZ-349 Logout failing

### DIFF
--- a/src/core/user.js
+++ b/src/core/user.js
@@ -163,10 +163,6 @@ Kinvey.User = /** @lends Kinvey.User */{
    * Logs out the active user.
    *
    * @param {Options} [options] Options.
-   * @param {boolean} [options.force=false] Reset the active user even if an
-   *          `InvalidCredentials` error is returned.
-   * @param {boolean} [options.silent=false] Succeed when there is no active
-   *          user.
    * @returns {Promise} The previous active user.
    */
   logout: function(options) {
@@ -175,7 +171,7 @@ Kinvey.User = /** @lends Kinvey.User */{
 
     // If `options.silent`, resolve immediately if there is no active user.
     var promise;
-    if(options.silent && null === Kinvey.getActiveUser()) {
+    if (null === Kinvey.getActiveUser()) {
       promise = Kinvey.Defer.resolve(null);
     }
     else {// Otherwise, attempt to logout the active user.
@@ -190,9 +186,8 @@ Kinvey.User = /** @lends Kinvey.User */{
         collection : '_logout',
         auth       : Auth.Session
       }, options).then(null, function(error) {
-        // If `options.force`, clear the active user on `INVALID_CREDENTIALS`.
-        if(options.force && (Kinvey.Error.INVALID_CREDENTIALS === error.name ||
-         Kinvey.Error.EMAIL_VERIFICATION_REQUIRED === error.name)) {
+        // Clear the active user on `INVALID_CREDENTIALS`.
+        if (Kinvey.Error.INVALID_CREDENTIALS === error.name || Kinvey.Error.EMAIL_VERIFICATION_REQUIRED === error.name)) {
           // Debug.
           if(KINVEY_DEBUG) {
             log('The user credentials are invalid. Returning success because of the force flag.');


### PR DESCRIPTION
Logout will now succeed if an error is received from the REST API call without requiring the developer to set options.force to true.

Logout will now succeed even if there is no active user to logout without requiring the developer to set options.silent to true.
