### PR TITLE
MLIBZ-324: Offline mode may have database bug

### DIFF
--- a/src/internals/persistence/local/indexeddb.js
+++ b/src/internals/persistence/local/indexeddb.js
@@ -131,7 +131,7 @@ var IDBAdapter = {
           return success(store);
         }
 
-        return error(new Kinvey.Error('Unable to open a transaction for the database. Please try this database transaction again.');
+        return error(new Kinvey.Error('Unable to open a transaction for the database. Please try this database transaction again.'));
       }
 
       // The collection does not exist. If we want to read only, return an error


### PR DESCRIPTION
When opening a transaction to update the database offline, sometimes the opening of the transaction will fail. This error needs to be caught and sent back to the user asynchronous. 

The database adapter now tries to open a transaction but captures any errors that occurs and calls the error callback with the error that occurred to notify the user.
