### PR TITLE
MLIBZ-667 SDK throws unnecessary warning about Database.find

### DIFF
--- a/src/core/persistence/database.js
+++ b/src/core/persistence/database.js
@@ -39,6 +39,9 @@ var Database = /** @lends Database */{
    * @return {Promise} Upgrade has completed
    */
   upgrade: function() {
+    var logLevel = Kinvey.Log.getLevel();
+    Kinvey.Log.disableAll();
+
     try {
       // Read the existing version of the database
       return Database.find(Database.versionTable).then(null, function() {
@@ -55,9 +58,11 @@ var Database = /** @lends Database */{
         // Save the version doc
         return Database.save(Database.versionTable, doc);
       }).then(function() {
+        Kinvey.Log.setLevel(logLevel);
         return;
       });
     } catch (err) {
+      Kinvey.Log.setLevel(logLevel);
       // Catch unsupported database methods error and
       // just resolve
       return Kinvey.Defer.resolve();


### PR DESCRIPTION
When the library is initialized, it will perform an upgrade operation on the database. NodeJS doesn't have a concept of a database resulting in a methodNotSupported error being thrown. This error would be logged and shown to the user causing concern when in fact nothing had gone wrong in the SDK. The error is now silenced.

Signed-off-by: Thomas Conner thomas@kinvey.com
