### PR TITLE
MLIBZ-1226: Login Invalid credentials status code 401(unauthorized) not detected in iPhone devices

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -1,0 +1,108 @@
+import pkg from '../package.json';
+
+// Helper function to detect the browser name and version.
+function browserDetect(ua) {
+  // Cast arguments.
+  ua = ua.toLowerCase();
+
+  // User-Agent patterns.
+  const rChrome = /(chrome)\/([\w]+)/;
+  const rFirefox = /(firefox)\/([\w.]+)/;
+  const rIE = /(msie) ([\w.]+)/i;
+  const rOpera = /(opera)(?:.*version)?[ \/]([\w.]+)/;
+  const rSafari = /(safari)\/([\w.]+)/;
+
+  return rChrome.exec(ua) || rFirefox.exec(ua) || rIE.exec(ua) ||
+    rOpera.exec(ua) || rSafari.exec(ua) || [];
+}
+
+function deviceInformation() {
+  let browser;
+  let platform;
+  let version;
+  let manufacturer;
+  let id;
+  const libraries = [];
+
+  // Platforms.
+  if (global.cordova !== undefined && global.device !== undefined) { // PhoneGap
+    const device = global.device;
+    libraries.push(`phonegap/${device.cordova}`);
+    platform = device.platform;
+    version = device.version;
+    manufacturer = device.model;
+    id = device.uuid;
+  } else if (global.Titanium !== undefined) { // Titanium.
+    libraries.push(`titanium/${global.Titanium.getVersion()}`);
+
+    // If mobileweb, extract browser information.
+    if (global.Titanium.Platform.getName() === 'mobileweb') {
+      browser = browserDetect(global.Titanium.Platform.getModel());
+      platform = browser[1];
+      version = browser[2];
+      manufacturer = global.Titanium.Platform.getOstype();
+    } else {
+      platform = global.Titanium.Platform.getOsname();
+      version = global.Titanium.Platform.getVersion();
+      manufacturer = global.Titanium.Platform.getManufacturer();
+    }
+
+    id = global.Titanium.Platform.getId();
+  } else if (global.forge !== undefined) { // Trigger.io
+    libraries.push(`triggerio/${global.forge.config.platform_version || ''}`);
+    id = global.forge.config.uuid;
+  } else if (process !== undefined) { // Node.js
+    platform = process.title;
+    version = process.version;
+    manufacturer = process.platform;
+  }
+
+  // Libraries.
+  if (global.angular !== undefined) { // AngularJS.
+    libraries.push(`angularjs/${global.angular.version.full}`);
+  }
+  if (global.Backbone !== undefined) { // Backbone.js.
+    libraries.push(`backbonejs/${global.Backbone.VERSION}`);
+  }
+  if (global.Ember !== undefined) { // Ember.js.
+    libraries.push(`emberjs/${global.Ember.VERSION}`);
+  }
+  if (global.jQuery !== undefined) { // jQuery.
+    libraries.push(`jquery/${global.jQuery.fn.jquery}`);
+  }
+  if (global.ko !== undefined) { // Knockout.
+    libraries.push(`knockout/${global.ko.version}`);
+  }
+  if (global.Zepto !== undefined) { // Zepto.js.
+    libraries.push('zeptojs');
+  }
+
+  // Default platform, most likely this is just a plain web app.
+  if ((platform === null || platform === undefined) && global.navigator) {
+    browser = browserDetect(global.navigator.userAgent);
+    platform = browser[1];
+    version = browser[2];
+    manufacturer = global.navigator.platform;
+  }
+
+  // Return the device information string.
+  const parts = [`js-${pkg.name}/${pkg.version}`];
+
+  if (libraries.length !== 0) { // Add external library information.
+    parts.push(`(${libraries.sort().join(', ')})`);
+  }
+
+  return parts.concat([platform, version, manufacturer, id]).map(part => {
+    if (!!part) {
+      return part.toString().replace(/\s/g, '_').toLowerCase();
+    }
+
+    return 'unknown';
+  }).join(' ');
+}
+
+export class Device {
+  static toString() {
+    return deviceInformation();
+  }
+}

--- a/src/requests/request.js
+++ b/src/requests/request.js
@@ -1,6 +1,7 @@
 import { KinveyRack } from '../rack/rack';
 import { Client } from '../client';
 import { KinveyError, NoActiveUserError } from '../errors';
+import { Device } from '../device';
 import UrlPattern from 'url-pattern';
 import regeneratorRuntime from 'regenerator-runtime'; // eslint-disable-line no-unused-vars
 import qs from 'qs';
@@ -524,11 +525,8 @@ export class KinveyRequestConfig extends RequestConfig {
       headers.remove('X-Kinvey-Custom-Request-Properties');
     }
 
-    if (global.KinveyDevice) {
-      headers.set('X-Kinvey-Device-Information', JSON.stringify(global.KinveyDevice.toJSON()));
-    } else {
-      headers.remove('X-Kinvey-Device-Information');
-    }
+    // Set Device information
+    headers.set('X-Kinvey-Device-Information', Device.toString());
 
     if (this.authType) {
       let authInfo;


### PR DESCRIPTION
This PR references [MLIBZ-1226](https://kinvey.atlassian.net/browse/MLIBZ-1226).
### Background Information

A login request that results in a `401 Invalid Credentials` status code response fails to reject the login promise when running a PhoneGap App on a native iOS device. The failed login response contains the `WWW-Authenticate` header. Unfortunately `UIWebView` contains a [bug](https://issues.apache.org/jira/browse/CB-2415) that shows an `UIAlertView` with options to retry or cancel the request that failed. PhoneGap is not presenting this `UIAlertView` and therefore the request never completes and the promise is never rejected.
### Fix

The Kinvey Backend uses the `X-Kinvey-Device-Information` header with the format used in 1.x of the SDK to detect if the login request originated from a JavaScript SDK and does not send the `WWW-Authenticate` header in the response. The `X-Kinvey-Device-Information` header needs to be updated to send the correct format.
### Changes
- Fixed `X-Kinvey-Device-Information` header to send device information using the format used in 1.x of the library. The Kinvey Backend uses this header to detect
