### PR TITLE
MLIBZ-1531 Grouping does not work

### DIFF
--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -114,6 +114,7 @@ export default class Aggregation {
     const json = {
       key: this.key,
       initial: this.initial,
+      reduce: this.reduceFn,
       reduceFn: this.reduceFn,
       condition: this.query ? this.query.toJSON().filter : {},
       query: this.query ? this.query.toJSON() : null
@@ -129,9 +130,9 @@ export default class Aggregation {
       aggregation.by(field);
     }
 
-    aggregation.initial = { result: 0 };
+    aggregation.initial = { count: 0 };
     aggregation.reduceFn = (doc, out) => {
-      out.result += 1;
+      out.count += 1;
       return out;
     };
     return aggregation;

--- a/src/datastore/src/cachestore.js
+++ b/src/datastore/src/cachestore.js
@@ -248,7 +248,7 @@ export default class CacheStore extends NetworkStore {
 
       // Fetch the cache entities
       const request = new CacheRequest({
-        method: RequestMethod.GET,
+        method: RequestMethod.POST,
         url: url.format({
           protocol: this.client.protocol,
           host: this.client.host,

--- a/src/datastore/src/networkstore.js
+++ b/src/datastore/src/networkstore.js
@@ -249,7 +249,7 @@ export default class NetworkStore {
 
       // Create the request
       const request = new KinveyRequest({
-        method: RequestMethod.GET,
+        method: RequestMethod.POST,
         authType: AuthType.Default,
         url: url.format({
           protocol: this.client.protocol,

--- a/src/datastore/src/syncstore.js
+++ b/src/datastore/src/syncstore.js
@@ -120,7 +120,7 @@ export default class SyncStore extends CacheStore {
 
       // Fetch the cache entities
       const request = new CacheRequest({
-        method: RequestMethod.GET,
+        method: RequestMethod.POST,
         url: url.format({
           protocol: this.client.protocol,
           host: this.client.host,

--- a/src/export.js
+++ b/src/export.js
@@ -11,6 +11,7 @@ import { Log } from './utils';
 export {
   Acl,
   Aggregation,
+  Aggregation as Group,
   AuthorizationGrant,
   CustomEndpoint,
   DataStore,

--- a/src/kinvey.js
+++ b/src/kinvey.js
@@ -213,6 +213,7 @@ Kinvey.DataStore = DataStore;
 Kinvey.DataStoreType = DataStoreType;
 Kinvey.File = FileStore;
 Kinvey.Files = FileStore;
+Kinvey.Group = Aggregation;
 Kinvey.Log = Log;
 Kinvey.Metadata = Metadata;
 Kinvey.Query = Query;

--- a/src/request/src/middleware/src/cache.js
+++ b/src/request/src/middleware/src/cache.js
@@ -19,7 +19,11 @@ export default class CacheMiddleware extends Middleware {
         promise = storage.find(collection);
       }
     } else if (method === 'POST' || method === 'PUT') {
-      promise = storage.save(collection, body);
+      if (entityId === '_group') {
+        promise = storage.find(collection);
+      } else {
+        promise = storage.save(collection, body);
+      }
     } else if (method === 'DELETE') {
       if (collection && entityId) {
         promise = storage.removeById(collection, entityId);
@@ -35,6 +39,10 @@ export default class CacheMiddleware extends Middleware {
         statusCode: method === 'POST' ? 201 : 200,
         data: data
       };
+
+      if (method === 'POST' && entityId === '_group') {
+        response.statusCode = 200;
+      }
 
       if (!data || isEmpty(data)) {
         response.statusCode = 204;

--- a/src/request/src/middleware/src/storage/index.js
+++ b/src/request/src/middleware/src/storage/index.js
@@ -73,20 +73,6 @@ export default class Storage {
       .then(adapter => adapter.findById(collection, id));
   }
 
-  // async group(collection, aggregation) {
-  //   const entities = await this.find(collection);
-
-  //   if (!(aggregation instanceof Aggregation)) {
-  //     aggregation = new Aggregation(result(aggregation, 'toJSON', aggregation));
-  //   }
-
-  //   if (entities.length > 0 && aggregation) {
-  //     return aggregation.process(entities);
-  //   }
-
-  //   return null;
-  // }
-
   save(collection, entities = []) {
     return queue.add(() => {
       let singular = false;

--- a/src/request/src/network.js
+++ b/src/request/src/network.js
@@ -172,6 +172,7 @@ export class KinveyRequest extends NetworkRequest {
 
     this.authType = options.authType || AuthType.None;
     this.query = options.query;
+    this.aggregation = options.aggregation;
     this.properties = options.properties || new Properties();
     this.skipBL = options.skipBL === true;
     this.trace = options.trace === true;


### PR DESCRIPTION
#### Description
This PR fixes a bug with grouping on the SDK. When trying to perform a group request, the SDK responds with the following error

```
{ 
  description: 'One of more identifier names in the request has an invalid format'
  debug: 'The entityName in the request starts with an _ (underscore)',
  code: 400 
}
```

#### Changes
- Send a group request with a `POST` and not a `GET`
- Set the aggregation on the request object
- Include the reduce function as a `reduce` property on the object representation of an aggregation
- Add unit test for grouping