### PR TITLE
Bugfix for sync() not persisting pulled entities

### DIFF
--- a/src/datastore/src/cachestore.js
+++ b/src/datastore/src/cachestore.js
@@ -829,7 +829,18 @@ export default class CacheStore extends NetworkStore {
    */
   sync(query, options) {
     options = assign({ useDeltaFetch: this.useDeltaFetch }, options);
-    return this.syncManager.sync(query, options);
+    return this.push(null, options)
+      .then((push) => {
+        const promise = this.pull(query, options)
+          .then((pull) => {
+            const result = {
+              push: push,
+              pull: pull
+            };
+            return result;
+          });
+        return promise;
+      });
   }
 
   clearSync(query, options) {

--- a/src/datastore/src/sync.js
+++ b/src/datastore/src/sync.js
@@ -578,21 +578,6 @@ export default class SyncManager {
       });
   }
 
-  sync(query, options = {}) {
-    return this.push(null, options)
-      .then((push) => {
-        const promise = this.pull(query, options)
-          .then((pull) => {
-            const result = {
-              push: push,
-              pull: pull
-            };
-            return result;
-          });
-        return promise;
-      });
-  }
-
   /**
    * Clear the sync table. A query can be provided to
    * only clear a subset of the sync table.


### PR DESCRIPTION
#### Description
Refers to MLIBZ-1553

On the `SyncStore`, the `sync()` method fails to persist the entities that are pulled from the backend. The `pull()` method works as intended.

#### Changes

The solution is to not delegate `sync()` to the `syncManager`, but instead implement it in the store itself. This way, the `push` and `pull` methods of the store get used.

#### Tests

Added a new unit test for `store.sync()`.
