### PR TITLE
Feedback on Error Object

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,4 +1,5 @@
 import ActiveUserError from './src/activeUser';
+import BaseError from './src/base';
 import FeatureUnavailableError from './src/featureUnavailable';
 import IncompleteRequestBodyError from './src/incompleteRequestBody';
 import InsufficientCredentialsError from './src/insufficientCredentials';
@@ -24,6 +25,7 @@ import TimeoutError from './src/timeout';
 // Export
 export {
   ActiveUserError,
+  BaseError,
   FeatureUnavailableError,
   IncompleteRequestBodyError,
   InsufficientCredentialsError,

--- a/src/errors/src/activeUser.js
+++ b/src/errors/src/activeUser.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class ActiveUserError extends BaseError {
-  constructor(message = 'An active user already exists.', debug, code) {
-    super('ActiveUserError', message, debug, code);
+  constructor(message = 'An active user already exists.', debug, code, kinveyRequestId) {
+    super('ActiveUserError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/activeUser.js
+++ b/src/errors/src/activeUser.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class ActiveUserError extends KinveyError {
+export default class ActiveUserError extends BaseError {
   constructor(message = 'An active user already exists.', debug, code) {
     super('ActiveUserError', message, debug, code);
   }

--- a/src/errors/src/base.js
+++ b/src/errors/src/base.js
@@ -1,0 +1,12 @@
+import ExtendableError from 'es6-error';
+
+export default class BaseError extends ExtendableError {
+  constructor(name, message = 'An error occurred.', debug = '', code = -1) {
+    super();
+    this.name = name || this.constructor.name;
+    this.message = message;
+    this.debug = debug;
+    this.code = code;
+    this.stack = (new Error(message)).stack;
+  }
+}

--- a/src/errors/src/base.js
+++ b/src/errors/src/base.js
@@ -1,12 +1,13 @@
 import ExtendableError from 'es6-error';
 
 export default class BaseError extends ExtendableError {
-  constructor(name, message = 'An error occurred.', debug = '', code = -1) {
+  constructor(name, message = 'An error occurred.', debug = '', code = -1, kinveyRequestId) {
     super();
     this.name = name || this.constructor.name;
     this.message = message;
     this.debug = debug;
     this.code = code;
+    this.kinveyRequestId = kinveyRequestId;
     this.stack = (new Error(message)).stack;
   }
 }

--- a/src/errors/src/featureUnavailable.js
+++ b/src/errors/src/featureUnavailable.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class FeatureUnavailableError extends KinveyError {
+export default class FeatureUnavailableError extends BaseError {
   constructor(message = 'Requested functionality is unavailable in this API version.', debug, code) {
     super('FeatureUnavailableError', message, debug, code);
   }

--- a/src/errors/src/featureUnavailable.js
+++ b/src/errors/src/featureUnavailable.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class FeatureUnavailableError extends BaseError {
-  constructor(message = 'Requested functionality is unavailable in this API version.', debug, code) {
-    super('FeatureUnavailableError', message, debug, code);
+  constructor(message = 'Requested functionality is unavailable in this API version.', debug, code, kinveyRequestId) {
+    super('FeatureUnavailableError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/incompleteRequestBody.js
+++ b/src/errors/src/incompleteRequestBody.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class IncompleteRequestBodyError extends KinveyError {
+export default class IncompleteRequestBodyError extends BaseError {
   constructor(message = 'The request body is either missing or incomplete.', debug, code) {
     super('IncompleteRequestBodyError', message, debug, code);
   }

--- a/src/errors/src/incompleteRequestBody.js
+++ b/src/errors/src/incompleteRequestBody.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class IncompleteRequestBodyError extends BaseError {
-  constructor(message = 'The request body is either missing or incomplete.', debug, code) {
-    super('IncompleteRequestBodyError', message, debug, code);
+  constructor(message = 'The request body is either missing or incomplete.', debug, code, kinveyRequestId) {
+    super('IncompleteRequestBodyError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/insufficientCredentials.js
+++ b/src/errors/src/insufficientCredentials.js
@@ -4,8 +4,8 @@ export default class InsufficientCredentialsError extends BaseError {
   constructor(message = 'The credentials used to authenticate this' +
     ' request are not authorized to run' +
     ' this operation. Please retry your' +
-    ' request with appropriate credentials.', debug, code) {
-    super('InsufficientCredentialsError', message, debug, code);
+    ' request with appropriate credentials.', debug, code, kinveyRequestId) {
+    super('InsufficientCredentialsError', message, debug, code, kinveyRequestId);
   }
 }
 

--- a/src/errors/src/insufficientCredentials.js
+++ b/src/errors/src/insufficientCredentials.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class InsufficientCredentialsError extends KinveyError {
+export default class InsufficientCredentialsError extends BaseError {
   constructor(message = 'The credentials used to authenticate this' +
     ' request are not authorized to run' +
     ' this operation. Please retry your' +

--- a/src/errors/src/invalidCredentials.js
+++ b/src/errors/src/invalidCredentials.js
@@ -1,8 +1,8 @@
 import BaseError from './base';
 
 export default class InvalidCredentialsError extends BaseError {
-  constructor(message = 'Invalid credentials. Please retry your request with correct credentials.', debug, code) {
-    super('InvalidCredentialsError', message, debug, code);
+  constructor(message = 'Invalid credentials. Please retry your request with correct credentials.', debug, code, kinveyRequestId) {
+    super('InvalidCredentialsError', message, debug, code, kinveyRequestId);
   }
 }
 

--- a/src/errors/src/invalidCredentials.js
+++ b/src/errors/src/invalidCredentials.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class InvalidCredentialsError extends KinveyError {
+export default class InvalidCredentialsError extends BaseError {
   constructor(message = 'Invalid credentials. Please retry your request with correct credentials.', debug, code) {
     super('InvalidCredentialsError', message, debug, code);
   }

--- a/src/errors/src/invalidIdentifier.js
+++ b/src/errors/src/invalidIdentifier.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class InvalidIdentifierError extends BaseError {
-  constructor(message = 'One of more identifier names in the request has an invalid format.', debug, code) {
-    super('InvalidIdentifierError', message, debug, code);
+  constructor(message = 'One of more identifier names in the request has an invalid format.', debug, code, kinveyRequestId) {
+    super('InvalidIdentifierError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/invalidIdentifier.js
+++ b/src/errors/src/invalidIdentifier.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class InvalidIdentifierError extends KinveyError {
+export default class InvalidIdentifierError extends BaseError {
   constructor(message = 'One of more identifier names in the request has an invalid format.', debug, code) {
     super('InvalidIdentifierError', message, debug, code);
   }

--- a/src/errors/src/invalidQuerySyntax.js
+++ b/src/errors/src/invalidQuerySyntax.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class InvalidQuerySyntaxError extends KinveyError {
+export default class InvalidQuerySyntaxError extends BaseError {
   constructor(message = 'The query string in the request has an invalid syntax.', debug, code) {
     super('InvalidQuerySyntaxError', message, debug, code);
   }

--- a/src/errors/src/invalidQuerySyntax.js
+++ b/src/errors/src/invalidQuerySyntax.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class InvalidQuerySyntaxError extends BaseError {
-  constructor(message = 'The query string in the request has an invalid syntax.', debug, code) {
-    super('InvalidQuerySyntaxError', message, debug, code);
+  constructor(message = 'The query string in the request has an invalid syntax.', debug, code, kinveyRequestId) {
+    super('InvalidQuerySyntaxError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/jsonParse.js
+++ b/src/errors/src/jsonParse.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class JSONParseError extends KinveyError {
+export default class JSONParseError extends BaseError {
   constructor(message = 'Unable to parse the JSON in the request.', debug, code) {
     super('JSONParseError', message, debug, code);
   }

--- a/src/errors/src/jsonParse.js
+++ b/src/errors/src/jsonParse.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class JSONParseError extends BaseError {
-  constructor(message = 'Unable to parse the JSON in the request.', debug, code) {
-    super('JSONParseError', message, debug, code);
+  constructor(message = 'Unable to parse the JSON in the request.', debug, code, kinveyRequestId) {
+    super('JSONParseError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/kinvey.js
+++ b/src/errors/src/kinvey.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class KinveyError extends BaseError {
-  constructor(message, debug, code) {
-    super('KinveyError', message, debug, code);
+  constructor(message, debug, code, kinveyRequestId) {
+    super('KinveyError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/kinvey.js
+++ b/src/errors/src/kinvey.js
@@ -1,12 +1,7 @@
-import ExtendableError from 'es6-error';
+import BaseError from './base';
 
-export default class KinveyError extends ExtendableError {
-  constructor(name, message = 'An error occurred.', debug = '', code = -1) {
-    super();
-    this.name = name || this.constructor.name;
-    this.message = message;
-    this.debug = debug;
-    this.code = code;
-    this.stack = (new Error(message)).stack;
+export default class KinveyError extends BaseError {
+  constructor(message, debug, code) {
+    super('KinveyError', message, debug, code);
   }
 }

--- a/src/errors/src/missingQuery.js
+++ b/src/errors/src/missingQuery.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class MissingQueryError extends BaseError {
-  constructor(message = 'The request is missing a query string.', debug, code) {
-    super('MissingQueryError', message, debug, code);
+  constructor(message = 'The request is missing a query string.', debug, code, kinveyRequestId) {
+    super('MissingQueryError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/missingQuery.js
+++ b/src/errors/src/missingQuery.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class MissingQueryError extends KinveyError {
+export default class MissingQueryError extends BaseError {
   constructor(message = 'The request is missing a query string.', debug, code) {
     super('MissingQueryError', message, debug, code);
   }

--- a/src/errors/src/missingRequestHeader.js
+++ b/src/errors/src/missingRequestHeader.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class MissingRequestHeaderError extends BaseError {
-  constructor(message = 'The request is missing a required header.', debug, code) {
-    super('MissingRequestHeaderError', message, debug, code);
+  constructor(message = 'The request is missing a required header.', debug, code, kinveyRequestId) {
+    super('MissingRequestHeaderError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/missingRequestHeader.js
+++ b/src/errors/src/missingRequestHeader.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class MissingRequestHeaderError extends KinveyError {
+export default class MissingRequestHeaderError extends BaseError {
   constructor(message = 'The request is missing a required header.', debug, code) {
     super('MissingRequestHeaderError', message, debug, code);
   }

--- a/src/errors/src/missingRequestParameter.js
+++ b/src/errors/src/missingRequestParameter.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class MissingRequestParameterError extends BaseError {
-  constructor(message = 'A required parameter is missing from the request.', debug, code) {
-    super('MissingRequestParameterError', message, debug, code);
+  constructor(message = 'A required parameter is missing from the request.', debug, code, kinveyRequestId) {
+    super('MissingRequestParameterError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/missingRequestParameter.js
+++ b/src/errors/src/missingRequestParameter.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class MissingRequestParameterError extends KinveyError {
+export default class MissingRequestParameterError extends BaseError {
   constructor(message = 'A required parameter is missing from the request.', debug, code) {
     super('MissingRequestParameterError', message, debug, code);
   }

--- a/src/errors/src/noActiveUser.js
+++ b/src/errors/src/noActiveUser.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class NoActiveUserError extends KinveyError {
+export default class NoActiveUserError extends BaseError {
   constructor(message = 'There is not an active user.', debug, code) {
     super('NoActiveUserError', message, debug, code);
   }

--- a/src/errors/src/noActiveUser.js
+++ b/src/errors/src/noActiveUser.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class NoActiveUserError extends BaseError {
-  constructor(message = 'There is not an active user.', debug, code) {
-    super('NoActiveUserError', message, debug, code);
+  constructor(message = 'There is not an active user.', debug, code, kinveyRequestId) {
+    super('NoActiveUserError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/noNetworkConnection.js
+++ b/src/errors/src/noNetworkConnection.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class NoNetworkConnectionError extends BaseError {
-  constructor(message = 'You do not have a network connection.', debug, code) {
-    super('NoNetworkConnectionError', message, debug, code);
+  constructor(message = 'You do not have a network connection.', debug, code, kinveyRequestId) {
+    super('NoNetworkConnectionError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/noNetworkConnection.js
+++ b/src/errors/src/noNetworkConnection.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class NoNetworkConnectionError extends KinveyError {
+export default class NoNetworkConnectionError extends BaseError {
   constructor(message = 'You do not have a network connection.', debug, code) {
     super('NoNetworkConnectionError', message, debug, code);
   }

--- a/src/errors/src/noResponse.js
+++ b/src/errors/src/noResponse.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class NoResponseError extends BaseError {
-  constructor(message = 'No response was provided.', debug, code) {
-    super('NoResponseError', message, debug, code);
+  constructor(message = 'No response was provided.', debug, code, kinveyRequestId) {
+    super('NoResponseError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/noResponse.js
+++ b/src/errors/src/noResponse.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class NoResponseError extends KinveyError {
+export default class NoResponseError extends BaseError {
   constructor(message = 'No response was provided.', debug, code) {
     super('NoResponseError', message, debug, code);
   }

--- a/src/errors/src/notFound.js
+++ b/src/errors/src/notFound.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class NotFoundError extends KinveyError {
+export default class NotFoundError extends BaseError {
   constructor(message = 'The item was not found.', debug, code = 404) {
     super('NotFoundError', message, debug, code);
   }

--- a/src/errors/src/notFound.js
+++ b/src/errors/src/notFound.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class NotFoundError extends BaseError {
-  constructor(message = 'The item was not found.', debug, code = 404) {
-    super('NotFoundError', message, debug, code);
+  constructor(message = 'The item was not found.', debug, code = 404, kinveyRequestId) {
+    super('NotFoundError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/parameterValueOutOfRange.js
+++ b/src/errors/src/parameterValueOutOfRange.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class ParameterValueOutOfRangeError extends BaseError {
-  constructor(message = 'The value specified for one of the request parameters is out of range.', debug, code) {
-    super('ParameterValueOutOfRangeError', message, debug, code);
+  constructor(message = 'The value specified for one of the request parameters is out of range.', debug, code, kinveyRequestId) {
+    super('ParameterValueOutOfRangeError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/parameterValueOutOfRange.js
+++ b/src/errors/src/parameterValueOutOfRange.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class ParameterValueOutOfRangeError extends KinveyError {
+export default class ParameterValueOutOfRangeError extends BaseError {
   constructor(message = 'The value specified for one of the request parameters is out of range.', debug, code) {
     super('ParameterValueOutOfRangeError', message, debug, code);
   }

--- a/src/errors/src/query.js
+++ b/src/errors/src/query.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class QueryError extends KinveyError {
+export default class QueryError extends BaseError {
   constructor(message = 'An error occurred with the query.', debug, code) {
     super('QueryError', message, debug, code);
   }

--- a/src/errors/src/query.js
+++ b/src/errors/src/query.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class QueryError extends BaseError {
-  constructor(message = 'An error occurred with the query.', debug, code) {
-    super('QueryError', message, debug, code);
+  constructor(message = 'An error occurred with the query.', debug, code, kinveyRequestId) {
+    super('QueryError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/server.js
+++ b/src/errors/src/server.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class ServerError extends KinveyError {
+export default class ServerError extends BaseError {
   constructor(message = 'An error occurred on the server.', debug, code = 500) {
     super('ServerError', message, debug, code);
   }

--- a/src/errors/src/server.js
+++ b/src/errors/src/server.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class ServerError extends BaseError {
-  constructor(message = 'An error occurred on the server.', debug, code = 500) {
-    super('ServerError', message, debug, code);
+  constructor(message = 'An error occurred on the server.', debug, code = 500, kinveyRequestId) {
+    super('ServerError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/errors/src/sync.js
+++ b/src/errors/src/sync.js
@@ -1,6 +1,6 @@
-import KinveyError from './kinvey';
+import BaseError from './base';
 
-export default class SyncError extends KinveyError {
+export default class SyncError extends BaseError {
   constructor(message = 'An error occurred during sync.', debug, code) {
     super('SyncError', message, debug, code);
   }

--- a/src/errors/src/sync.js
+++ b/src/errors/src/sync.js
@@ -1,7 +1,7 @@
 import BaseError from './base';
 
 export default class SyncError extends BaseError {
-  constructor(message = 'An error occurred during sync.', debug, code) {
-    super('SyncError', message, debug, code);
+  constructor(message = 'An error occurred during sync.', debug, code, kinveyRequestId) {
+    super('SyncError', message, debug, code, kinveyRequestId);
   }
 }

--- a/src/request/src/response.js
+++ b/src/request/src/response.js
@@ -74,16 +74,17 @@ export default class Response {
     const message = data.message || data.description;
     const debug = data.debug;
     const code = this.statusCode;
+    const kinveyRequestId = this.headers.get('X-Kinvey-Request-ID');
 
     if (code === StatusCode.Unauthorized) {
-      return new InsufficientCredentialsError(message, debug, code);
+      return new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
     } else if (code === StatusCode.NotFound) {
-      return new NotFoundError(message, debug, code);
+      return new NotFoundError(message, debug, code, kinveyRequestId);
     } else if (code === StatusCode.ServerError) {
-      return new ServerError(message, debug, code);
+      return new ServerError(message, debug, code, kinveyRequestId);
     }
 
-    return new KinveyError(name, message, debug, code);
+    return new KinveyError(name, message, debug, code, kinveyRequestId);
   }
 
   isSuccess() {
@@ -107,38 +108,39 @@ export class KinveyResponse extends Response {
     const message = data.message || data.description;
     const debug = data.debug;
     const code = this.statusCode;
+    const kinveyRequestId = this.headers.get('X-Kinvey-Request-ID');
 
     if (name === 'FeatureUnavailableError') {
-      return new FeatureUnavailableError(message, debug, code);
+      return new FeatureUnavailableError(message, debug, code, kinveyRequestId);
     } else if (name === 'IncompleteRequestBodyError') {
-      return new IncompleteRequestBodyError(message, debug, code);
+      return new IncompleteRequestBodyError(message, debug, code, kinveyRequestId);
     } else if (name === 'InsufficientCredentials') {
-      return new InsufficientCredentialsError(message, debug, code);
+      return new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidCredentials') {
-      return new InvalidCredentialsError(message, debug, code);
+      return new InvalidCredentialsError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidIdentifierError') {
-      return new InvalidIdentifierError(message, debug, code);
+      return new InvalidIdentifierError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidQuerySyntaxError') {
-      return new InvalidQuerySyntaxError(message, debug, code);
+      return new InvalidQuerySyntaxError(message, debug, code, kinveyRequestId);
     } else if (name === 'JSONParseError') {
-      return new JSONParseError(message, debug, code);
+      return new JSONParseError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingQueryError') {
-      return new MissingQueryError(message, debug, code);
+      return new MissingQueryError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingRequestHeaderError') {
-      return new MissingRequestHeaderError(message, debug, code);
+      return new MissingRequestHeaderError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingRequestParameterError') {
-      return new MissingRequestParameterError(message, debug, code);
+      return new MissingRequestParameterError(message, debug, code, kinveyRequestId);
     } else if (name === 'EntityNotFound'
         || name === 'CollectionNotFound'
         || name === 'AppNotFound'
         || name === 'UserNotFound'
         || name === 'BlobNotFound'
         || name === 'DocumentNotFound') {
-      return new NotFoundError(message, debug, code);
+      return new NotFoundError(message, debug, code, kinveyRequestId);
     } else if (name === 'ParameterValueOutOfRangeError') {
-      return new ParameterValueOutOfRangeError(message, debug, code);
+      return new ParameterValueOutOfRangeError(message, debug, code, kinveyRequestId);
     } else if (name === 'ServerError') {
-      return new ServerError(message, debug, code);
+      return new ServerError(message, debug, code, kinveyRequestId);
     }
 
     return super.error;

--- a/src/request/src/response.js
+++ b/src/request/src/response.js
@@ -74,16 +74,20 @@ export default class Response {
     const debug = data.debug;
     const code = this.statusCode;
     const kinveyRequestId = this.headers.get('X-Kinvey-Request-ID');
+    let error;
 
     if (code === StatusCode.Unauthorized) {
-      return new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
+      error = new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
     } else if (code === StatusCode.NotFound) {
-      return new NotFoundError(message, debug, code, kinveyRequestId);
+      error = new NotFoundError(message, debug, code, kinveyRequestId);
     } else if (code === StatusCode.ServerError) {
-      return new ServerError(message, debug, code, kinveyRequestId);
+      error = new ServerError(message, debug, code, kinveyRequestId);
+    } else {
+      error = new KinveyError(message, debug, code, kinveyRequestId);
     }
 
-    return new KinveyError(message, debug, code, kinveyRequestId);
+    error.name = name;
+    return error;
   }
 
   isSuccess() {
@@ -108,40 +112,44 @@ export class KinveyResponse extends Response {
     const debug = data.debug;
     const code = this.statusCode;
     const kinveyRequestId = this.headers.get('X-Kinvey-Request-ID');
+    let error;
 
     if (name === 'FeatureUnavailableError') {
-      return new FeatureUnavailableError(message, debug, code, kinveyRequestId);
+      error = new FeatureUnavailableError(message, debug, code, kinveyRequestId);
     } else if (name === 'IncompleteRequestBodyError') {
-      return new IncompleteRequestBodyError(message, debug, code, kinveyRequestId);
+      error = new IncompleteRequestBodyError(message, debug, code, kinveyRequestId);
     } else if (name === 'InsufficientCredentials') {
-      return new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
+      error = new InsufficientCredentialsError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidCredentials') {
-      return new InvalidCredentialsError(message, debug, code, kinveyRequestId);
+      error = new InvalidCredentialsError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidIdentifierError') {
-      return new InvalidIdentifierError(message, debug, code, kinveyRequestId);
+      error = new InvalidIdentifierError(message, debug, code, kinveyRequestId);
     } else if (name === 'InvalidQuerySyntaxError') {
-      return new InvalidQuerySyntaxError(message, debug, code, kinveyRequestId);
+      error = new InvalidQuerySyntaxError(message, debug, code, kinveyRequestId);
     } else if (name === 'JSONParseError') {
-      return new JSONParseError(message, debug, code, kinveyRequestId);
+      error = new JSONParseError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingQueryError') {
-      return new MissingQueryError(message, debug, code, kinveyRequestId);
+      error = new MissingQueryError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingRequestHeaderError') {
-      return new MissingRequestHeaderError(message, debug, code, kinveyRequestId);
+      error = new MissingRequestHeaderError(message, debug, code, kinveyRequestId);
     } else if (name === 'MissingRequestParameterError') {
-      return new MissingRequestParameterError(message, debug, code, kinveyRequestId);
+      error = new MissingRequestParameterError(message, debug, code, kinveyRequestId);
     } else if (name === 'EntityNotFound'
         || name === 'CollectionNotFound'
         || name === 'AppNotFound'
         || name === 'UserNotFound'
         || name === 'BlobNotFound'
         || name === 'DocumentNotFound') {
-      return new NotFoundError(message, debug, code, kinveyRequestId);
+      error = new NotFoundError(message, debug, code, kinveyRequestId);
     } else if (name === 'ParameterValueOutOfRangeError') {
-      return new ParameterValueOutOfRangeError(message, debug, code, kinveyRequestId);
+      error = new ParameterValueOutOfRangeError(message, debug, code, kinveyRequestId);
     } else if (name === 'ServerError') {
-      return new ServerError(message, debug, code, kinveyRequestId);
+      error = new ServerError(message, debug, code, kinveyRequestId);
+    } else {
+      return super.error;
     }
 
-    return super.error;
+    error.name = name;
+    return error;
   }
 }

--- a/src/request/src/response.js
+++ b/src/request/src/response.js
@@ -70,7 +70,6 @@ export default class Response {
     }
 
     const data = this.data || {};
-    const name = data.name || data.error;
     const message = data.message || data.description;
     const debug = data.debug;
     const code = this.statusCode;
@@ -84,7 +83,7 @@ export default class Response {
       return new ServerError(message, debug, code, kinveyRequestId);
     }
 
-    return new KinveyError(name, message, debug, code, kinveyRequestId);
+    return new KinveyError(message, debug, code, kinveyRequestId);
   }
 
   isSuccess() {

--- a/src/request/src/response.js
+++ b/src/request/src/response.js
@@ -16,6 +16,7 @@ import {
   ParameterValueOutOfRangeError,
   ServerError
 } from '../../errors';
+import { isDefined } from '../../utils';
 
 /**
  * @private
@@ -70,6 +71,7 @@ export default class Response {
     }
 
     const data = this.data || {};
+    const name = data.name || data.error;
     const message = data.message || data.description;
     const debug = data.debug;
     const code = this.statusCode;
@@ -86,7 +88,10 @@ export default class Response {
       error = new KinveyError(message, debug, code, kinveyRequestId);
     }
 
-    error.name = name;
+    if (isDefined(name)) {
+      error.name = name;
+    }
+
     return error;
   }
 
@@ -149,7 +154,10 @@ export class KinveyResponse extends Response {
       return super.error;
     }
 
-    error.name = name;
+    if (isDefined(name)) {
+      error.name = name;
+    }
+
     return error;
   }
 }

--- a/test/unit/errors/activeUser.test.js
+++ b/test/unit/errors/activeUser.test.js
@@ -63,15 +63,9 @@ describe('ActiveUserError', () => {
   });
 
   describe('kinveyRequestId', () => {
-    it('should return undefined as the default value', () => {
+    it('should return undefined', () => {
       const error = new ActiveUserError();
       expect(error.kinveyRequestId).toEqual(undefined);
-    });
-
-    it('should return 1', () => {
-      const kinveyRequestId = 1;
-      const error = new ActiveUserError(null, null, null, kinveyRequestId);
-      expect(error.kinveyRequestId).toEqual(kinveyRequestId);
     });
   });
 });

--- a/test/unit/errors/activeUser.test.js
+++ b/test/unit/errors/activeUser.test.js
@@ -1,4 +1,4 @@
-import { ActiveUserError, KinveyError } from 'src/errors';
+import { ActiveUserError, BaseError } from '../../../src/errors';
 import expect from 'expect';
 
 describe('ActiveUserError', () => {
@@ -8,9 +8,9 @@ describe('ActiveUserError', () => {
       expect(error instanceof ActiveUserError).toEqual(true);
     });
 
-    it('should be an instance of KinveyError', () => {
+    it('should be an instance of BaseError', () => {
       const error = new ActiveUserError();
-      expect(error instanceof KinveyError).toEqual(true);
+      expect(error instanceof BaseError).toEqual(true);
     });
 
     it('should be an instance of Error', () => {
@@ -53,12 +53,25 @@ describe('ActiveUserError', () => {
   describe('code', () => {
     it('should return the default code -1', () => {
       const error = new ActiveUserError();
-      expect(error.debug).toEqual('');
+      expect(error.code).toEqual(-1);
     });
 
     it('should return the custom code 309', () => {
       const error = new ActiveUserError(undefined, undefined, 309);
       expect(error.code).toEqual(309);
+    });
+  });
+
+  describe('kinveyRequestId', () => {
+    it('should return undefined as the default value', () => {
+      const error = new ActiveUserError();
+      expect(error.kinveyRequestId).toEqual(undefined);
+    });
+
+    it('should return 1', () => {
+      const kinveyRequestId = 1;
+      const error = new ActiveUserError(null, null, null, kinveyRequestId);
+      expect(error.kinveyRequestId).toEqual(kinveyRequestId);
     });
   });
 });


### PR DESCRIPTION
#### Description
This PR fixes many issues with Error objects. It sets the name property to the correct name of the error. It adds the `X-Kinvey-Request-Id` as a property on the error.

#### Changes
- Set `name`property to name of the error.
- Add `BaseError` extended by all custom errors.
- Add unit test to check if `X-Kinvey-Request-Id` is set properly for an error.
