### PR TITLE
MLIBZ-1614: User Discovery

### DIFF
--- a/src/datastore/src/userstore.js
+++ b/src/datastore/src/userstore.js
@@ -1,5 +1,6 @@
 import { AuthType, RequestMethod, KinveyRequest } from '../../request';
 import { KinveyError } from '../../errors';
+import { KinveyObservable, isDefined } from '../../utils';
 import NetworkStore from './networkstore';
 import Promise from 'es6-promise';
 import url from 'url';
@@ -30,6 +31,49 @@ class UserStore extends NetworkStore {
    */
   create() {
     return Promise.reject(new KinveyError('Please use `User.signup()` to create a user.'));
+  }
+
+  /**
+   * Find all users. A query can be optionally provided to return
+   * a subset of all users or omitted to return all users.
+   *
+   * @param {Query} [query] Query used to filter entities.
+   * @param {Object} [options] Options
+   * @param {Boolean} [options.discover] Discover users.
+   * @return {Observable} Observable.
+   */
+  find(query, options = {}) {
+    // If `options.discover`, use
+    // [User Discovery](http://devcenter.kinvey.com/guides/users#lookup)
+    // instead of querying the user namespace directly.
+    if (options.discover === true) {
+      const stream = KinveyObservable.create((observer) => {
+        const request = new KinveyRequest({
+          method: RequestMethod.POST,
+          authType: AuthType.Default,
+          url: url.format({
+            protocol: this.client.protocol,
+            host: this.client.host,
+            pathname: `${this.pathname}/_lookup`,
+            query: options.query
+          }),
+          properties: options.properties,
+          body: isDefined(query) ? query.toPlainObject().filter : null,
+          timeout: options.timeout,
+          client: this.client
+        });
+
+        // Execute the request
+        return request.execute()
+          .then(response => response.data)
+          .then(data => observer.next(data))
+          .then(() => observer.complete())
+          .catch(error => observer.error(error));
+      });
+      return stream;
+    }
+
+    return super.find(query, options);
   }
 
   /**

--- a/src/datastore/src/userstore.js
+++ b/src/datastore/src/userstore.js
@@ -1,6 +1,7 @@
 import { AuthType, RequestMethod, KinveyRequest } from '../../request';
 import { KinveyError } from '../../errors';
 import { KinveyObservable, isDefined } from '../../utils';
+import Query from '../../query';
 import NetworkStore from './networkstore';
 import Promise from 'es6-promise';
 import url from 'url';
@@ -48,6 +49,11 @@ class UserStore extends NetworkStore {
     // instead of querying the user namespace directly.
     if (options.discover === true) {
       const stream = KinveyObservable.create((observer) => {
+        // Check that the query is valid
+        if (isDefined(query) && !(query instanceof Query)) {
+          return observer.error(new KinveyError('Invalid query. It must be an instance of the Query class.'));
+        }
+
         const request = new KinveyRequest({
           method: RequestMethod.POST,
           authType: AuthType.Default,

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -893,11 +893,21 @@ export default class User {
    *
    * @param {Query} [query] Query used to filter entities.
    * @param {Object} [options] Options
-   * @param {boolean} [options.discover] Discover users.
    * @return {Observable} Observable.
    */
   static find(query, options = {}) {
     return store.find(query, options);
+  }
+
+  /**
+   * Lookup users.
+   *
+   * @param {Query} [query] Query used to filter entities.
+   * @param {Object} [options] Options
+   * @return {Observable} Observable.
+   */
+  static lookup(query, options = {}) {
+    return store.lookup(query, options);
   }
 
   /**

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -889,17 +889,6 @@ export default class User {
   }
 
   /**
-   * Find users.
-   *
-   * @param {Query} [query] Query used to filter entities.
-   * @param {Object} [options] Options
-   * @return {Observable} Observable.
-   */
-  static find(query, options = {}) {
-    return store.find(query, options);
-  }
-
-  /**
    * Lookup users.
    *
    * @param {Query} [query] Query used to filter entities.

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -889,6 +889,18 @@ export default class User {
   }
 
   /**
+   * Find users.
+   *
+   * @param {Query} [query] Query used to filter entities.
+   * @param {Object} [options] Options
+   * @param {boolean} [options.discover] Discover users.
+   * @return {Observable} Observable.
+   */
+  static find(query, options = {}) {
+    return store.find(query, options);
+  }
+
+  /**
    * Check if a username already exists.
    *
    * @param {string} username Username

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -289,7 +289,7 @@ export default class User {
    * @param {Object} [options={}] Options
    * @return {Promise<User>} The user.
    */
-  static login(username, password, options) {
+  static login(username, password, options = {}) {
     const user = new this({}, options);
     return user.login(username, password, options);
   }
@@ -340,7 +340,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  connectIdentity(identity, session, options) {
+  connectIdentity(identity, session, options = {}) {
     const isActive = this.isActive();
     const data = {};
     const socialIdentity = data[socialIdentityAttribute] || {};
@@ -370,7 +370,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  static connectIdentity(identity, session, options) {
+  static connectIdentity(identity, session, options = {}) {
     const user = new this({}, options);
     return user.connectIdentity(identity, session, options);
   }
@@ -385,7 +385,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  connectWithIdentity(identity, session, options) {
+  connectWithIdentity(identity, session, options = {}) {
     return this.connectIdentity(identity, session, options);
   }
 
@@ -395,7 +395,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  connectFacebook(clientId, options) {
+  connectFacebook(clientId, options = {}) {
     const facebook = new Facebook({ client: this.client });
     return facebook.login(clientId, options)
       .then(session => this.connectIdentity(Facebook.identity, session, options));
@@ -407,7 +407,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  static connectFacebook(clientId, options) {
+  static connectFacebook(clientId, options = {}) {
     const user = new this({}, options);
     return user.connectFacebook(clientId, options);
   }
@@ -418,7 +418,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  disconnectFacebook(options) {
+  disconnectFacebook(options = {}) {
     return this.disconnectIdentity(Facebook.identity, options);
   }
 
@@ -428,7 +428,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  connectGoogle(clientId, options) {
+  connectGoogle(clientId, options = {}) {
     const google = new Google({ client: this.client });
     return google.login(clientId, options)
       .then(session => this.connectIdentity(Google.identity, session, options));
@@ -440,7 +440,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  static connectGoogle(clientId, options) {
+  static connectGoogle(clientId, options = {}) {
     const user = new this({}, options);
     return user.connectGoogle(clientId, options);
   }
@@ -451,7 +451,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  disconnectGoogle(options) {
+  disconnectGoogle(options = {}) {
     return this.disconnectIdentity(Google.identity, options);
   }
 
@@ -461,7 +461,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  googleconnectLinkedIn(clientId, options) {
+  googleconnectLinkedIn(clientId, options = {}) {
     const linkedIn = new LinkedIn({ client: this.client });
     return linkedIn.login(clientId, options)
       .then(session => this.connectIdentity(LinkedIn.identity, session, options));
@@ -473,7 +473,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  static connectLinkedIn(clientId, options) {
+  static connectLinkedIn(clientId, options = {}) {
     const user = new this({}, options);
     return user.connectLinkedIn(clientId, options);
   }
@@ -484,7 +484,7 @@ export default class User {
    * @param  {Object}         [options]     Options
    * @return {Promise<User>}                The user.
    */
-  disconnectLinkedIn(options) {
+  disconnectLinkedIn(options = {}) {
     return this.disconnectIdentity(LinkedIn.identity, options);
   }
 
@@ -496,7 +496,7 @@ export default class User {
    * @param  {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  disconnectIdentity(identity, options) {
+  disconnectIdentity(identity, options = {}) {
     let promise = Promise.resolve();
 
     if (identity === Facebook.identity) {
@@ -644,7 +644,7 @@ export default class User {
    *                                       being signed up.
    * @return {Promise<User>} The user.
    */
-  static signup(data, options) {
+  static signup(data, options = {}) {
     const user = new this({}, options);
     return user.signup(data, options);
   }
@@ -659,7 +659,7 @@ export default class User {
    *                                       being signed up.
    * @return {Promise<User>} The user.
    */
-  signupWithIdentity(identity, session, options) {
+  signupWithIdentity(identity, session, options = {}) {
     const data = {};
     data[socialIdentityAttribute] = {};
     data[socialIdentityAttribute][identity] = session;
@@ -676,7 +676,7 @@ export default class User {
    *                                       being signed up.
    * @return {Promise<User>} The user.
    */
-  static signupWithIdentity(identity, session, options) {
+  static signupWithIdentity(identity, session, options = {}) {
     const user = new this({}, options);
     return user.signupWithIdentity(identity, session, options);
   }
@@ -688,7 +688,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  update(data, options) {
+  update(data, options = {}) {
     data = assign(this.data, data);
     return store.update(data, options)
       .then(() => {
@@ -712,7 +712,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  static update(data, options) {
+  static update(data, options = {}) {
     const activeUser = User.getActiveUser(options.client);
 
     if (isDefined(activeUser)) {
@@ -769,7 +769,7 @@ export default class User {
    * @param {Object} [options={}] Options
    * @return {Promise<User>} The user.
    */
-  static me(options) {
+  static me(options = {}) {
     const activeUser = User.getActiveUser(options.client);
 
     if (activeUser) {
@@ -895,7 +895,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {boolean} True if the username already exists otherwise false.
    */
-  static exists(username, options) {
+  static exists(username, options = {}) {
     return store.exists(username, options);
   }
 
@@ -906,7 +906,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<Object>} The response.
    */
-  static restore(id, options) {
+  static restore(id, options = {}) {
     return store.restore(id, options);
   }
 }

--- a/test/unit/datastore/userstore.test.js
+++ b/test/unit/datastore/userstore.test.js
@@ -1,0 +1,96 @@
+import { UserStore as store } from 'src/datastore';
+import Query from 'src/query';
+import { KinveyError } from 'src/errors';
+import { randomString } from 'src/utils';
+import nock from 'nock';
+import expect from 'expect';
+
+describe('UserStore', function () {
+  describe('find()', function() {
+    describe('user discovery', function() {
+      it('should throw an error if the query argument is not an instance of the Query class', function() {
+        return store.find({}, { discover: true })
+          .toPromise()
+          .catch((error) => {
+            expect(error).toBeA(KinveyError);
+          });
+      });
+
+      it('should return an array of users', function() {
+        const USERS = [{
+          _id: randomString(),
+          username: randomString(),
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }, {
+          _id: randomString(),
+          username: randomString(),
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }];
+
+        // Kinvey API response
+        nock(this.client.apiHostname, { encodedQueryParams: true })
+          .post(`/user/${this.client.appKey}/_lookup`)
+          .reply(200, USERS);
+
+        return store.find(null, { discover: true })
+          .toPromise()
+          .then((users) => {
+            expect(users).toEqual(USERS);
+          });
+      });
+
+      it('should return an array of users matching the query', function() {
+        const USERS = [{
+          _id: randomString(),
+          username: 'foo',
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }, {
+          _id: randomString(),
+          username: 'foo',
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }];
+        const query = new Query();
+        query.equalTo('username', 'foo');
+
+        // Kinvey API response
+        nock(this.client.apiHostname, { encodedQueryParams: true })
+          .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
+          .reply(200, USERS);
+
+        return store.find(query, { discover: true })
+          .toPromise()
+          .then((users) => {
+            expect(users).toEqual(USERS);
+
+            users.forEach(function(user) {
+              expect(user.username).toEqual('foo');
+            });
+          });
+      });
+    });
+  });
+});

--- a/test/unit/datastore/userstore.test.js
+++ b/test/unit/datastore/userstore.test.js
@@ -6,91 +6,89 @@ import nock from 'nock';
 import expect from 'expect';
 
 describe('UserStore', function () {
-  describe('find()', function() {
-    describe('user discovery', function() {
-      it('should throw an error if the query argument is not an instance of the Query class', function() {
-        return store.find({}, { discover: true })
-          .toPromise()
-          .catch((error) => {
-            expect(error).toBeA(KinveyError);
+  describe('lookup()', function() {
+    it('should throw an error if the query argument is not an instance of the Query class', function() {
+      return store.lookup({})
+        .toPromise()
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+        });
+    });
+
+    it('should return an array of users', function() {
+      const USERS = [{
+        _id: randomString(),
+        username: randomString(),
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }, {
+        _id: randomString(),
+        username: randomString(),
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }];
+
+      // Kinvey API response
+      nock(this.client.apiHostname, { encodedQueryParams: true })
+        .post(`/user/${this.client.appKey}/_lookup`)
+        .reply(200, USERS);
+
+      return store.lookup()
+        .toPromise()
+        .then((users) => {
+          expect(users).toEqual(USERS);
+        });
+    });
+
+    it('should return an array of users matching the query', function() {
+      const USERS = [{
+        _id: randomString(),
+        username: 'foo',
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }, {
+        _id: randomString(),
+        username: 'foo',
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }];
+      const query = new Query();
+      query.equalTo('username', 'foo');
+
+      // Kinvey API response
+      nock(this.client.apiHostname, { encodedQueryParams: true })
+        .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
+        .reply(200, USERS);
+
+      return store.lookup(query)
+        .toPromise()
+        .then((users) => {
+          expect(users).toEqual(USERS);
+
+          users.forEach(function(user) {
+            expect(user.username).toEqual('foo');
           });
-      });
-
-      it('should return an array of users', function() {
-        const USERS = [{
-          _id: randomString(),
-          username: randomString(),
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }, {
-          _id: randomString(),
-          username: randomString(),
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }];
-
-        // Kinvey API response
-        nock(this.client.apiHostname, { encodedQueryParams: true })
-          .post(`/user/${this.client.appKey}/_lookup`)
-          .reply(200, USERS);
-
-        return store.find(null, { discover: true })
-          .toPromise()
-          .then((users) => {
-            expect(users).toEqual(USERS);
-          });
-      });
-
-      it('should return an array of users matching the query', function() {
-        const USERS = [{
-          _id: randomString(),
-          username: 'foo',
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }, {
-          _id: randomString(),
-          username: 'foo',
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }];
-        const query = new Query();
-        query.equalTo('username', 'foo');
-
-        // Kinvey API response
-        nock(this.client.apiHostname, { encodedQueryParams: true })
-          .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
-          .reply(200, USERS);
-
-        return store.find(query, { discover: true })
-          .toPromise()
-          .then((users) => {
-            expect(users).toEqual(USERS);
-
-            users.forEach(function(user) {
-              expect(user.username).toEqual('foo');
-            });
-          });
-      });
+        });
     });
   });
 });

--- a/test/unit/entity/user.test.js
+++ b/test/unit/entity/user.test.js
@@ -302,91 +302,89 @@ describe('User', function() {
     });
   });
 
-  describe('find()', function() {
-    describe('user discovery', function() {
-      it('should throw an error if the query argument is not an instance of the Query class', function() {
-        return User.find({}, { discover: true })
-          .toPromise()
-          .catch((error) => {
-            expect(error).toBeA(KinveyError);
+  describe('lookup()', function() {
+    it('should throw an error if the query argument is not an instance of the Query class', function() {
+      return User.find({}, { discover: true })
+        .toPromise()
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+        });
+    });
+
+    it('should return an array of users', function() {
+      const USERS = [{
+        _id: randomString(),
+        username: randomString(),
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }, {
+        _id: randomString(),
+        username: randomString(),
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }];
+
+      // Kinvey API response
+      nock(this.client.apiHostname, { encodedQueryParams: true })
+        .post(`/user/${this.client.appKey}/_lookup`)
+        .reply(200, USERS);
+
+      return User.lookup()
+        .toPromise()
+        .then((users) => {
+          expect(users).toEqual(USERS);
+        });
+    });
+
+    it('should return an array of users matching the query', function() {
+      const USERS = [{
+        _id: randomString(),
+        username: 'foo',
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }, {
+        _id: randomString(),
+        username: 'foo',
+        _acl: {
+          creator: randomString()
+        },
+        _kmd: {
+          lmt: new Date().toISOString(),
+          ect: new Date().toISOString()
+        }
+      }];
+      const query = new Query();
+      query.equalTo('username', 'foo');
+
+      // Kinvey API response
+      nock(this.client.apiHostname, { encodedQueryParams: true })
+        .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
+        .reply(200, USERS);
+
+      return User.lookup(query)
+        .toPromise()
+        .then((users) => {
+          expect(users).toEqual(USERS);
+
+          users.forEach(function(user) {
+            expect(user.username).toEqual('foo');
           });
-      });
-
-      it('should return an array of users', function() {
-        const USERS = [{
-          _id: randomString(),
-          username: randomString(),
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }, {
-          _id: randomString(),
-          username: randomString(),
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }];
-
-        // Kinvey API response
-        nock(this.client.apiHostname, { encodedQueryParams: true })
-          .post(`/user/${this.client.appKey}/_lookup`)
-          .reply(200, USERS);
-
-        return User.find(null, { discover: true })
-          .toPromise()
-          .then((users) => {
-            expect(users).toEqual(USERS);
-          });
-      });
-
-      it('should return an array of users matching the query', function() {
-        const USERS = [{
-          _id: randomString(),
-          username: 'foo',
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }, {
-          _id: randomString(),
-          username: 'foo',
-          _acl: {
-            creator: randomString()
-          },
-          _kmd: {
-            lmt: new Date().toISOString(),
-            ect: new Date().toISOString()
-          }
-        }];
-        const query = new Query();
-        query.equalTo('username', 'foo');
-
-        // Kinvey API response
-        nock(this.client.apiHostname, { encodedQueryParams: true })
-          .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
-          .reply(200, USERS);
-
-        return User.find(query, { discover: true })
-          .toPromise()
-          .then((users) => {
-            expect(users).toEqual(USERS);
-
-            users.forEach(function(user) {
-              expect(user.username).toEqual('foo');
-            });
-          });
-      });
+        });
     });
   });
 });

--- a/test/unit/entity/user.test.js
+++ b/test/unit/entity/user.test.js
@@ -2,6 +2,7 @@ import { User } from 'src/entity';
 import { randomString } from 'src/utils';
 import { ActiveUserError, InvalidCredentialsError, KinveyError } from 'src/errors';
 import { TestUser } from '../mocks';
+import Query from 'src/query';
 import expect from 'expect';
 import nock from 'nock';
 const rpcNamespace = process.env.KINVEY_RPC_NAMESPACE || 'rpc';
@@ -298,6 +299,94 @@ describe('User', function() {
 
       const response = await User.forgotUsername(email);
       expect(response).toEqual({});
+    });
+  });
+
+  describe('find()', function() {
+    describe('user discovery', function() {
+      it('should throw an error if the query argument is not an instance of the Query class', function() {
+        return User.find({}, { discover: true })
+          .toPromise()
+          .catch((error) => {
+            expect(error).toBeA(KinveyError);
+          });
+      });
+
+      it('should return an array of users', function() {
+        const USERS = [{
+          _id: randomString(),
+          username: randomString(),
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }, {
+          _id: randomString(),
+          username: randomString(),
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }];
+
+        // Kinvey API response
+        nock(this.client.apiHostname, { encodedQueryParams: true })
+          .post(`/user/${this.client.appKey}/_lookup`)
+          .reply(200, USERS);
+
+        return User.find(null, { discover: true })
+          .toPromise()
+          .then((users) => {
+            expect(users).toEqual(USERS);
+          });
+      });
+
+      it('should return an array of users matching the query', function() {
+        const USERS = [{
+          _id: randomString(),
+          username: 'foo',
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }, {
+          _id: randomString(),
+          username: 'foo',
+          _acl: {
+            creator: randomString()
+          },
+          _kmd: {
+            lmt: new Date().toISOString(),
+            ect: new Date().toISOString()
+          }
+        }];
+        const query = new Query();
+        query.equalTo('username', 'foo');
+
+        // Kinvey API response
+        nock(this.client.apiHostname, { encodedQueryParams: true })
+          .post(`/user/${this.client.appKey}/_lookup`, query.toPlainObject().filter)
+          .reply(200, USERS);
+
+        return User.find(query, { discover: true })
+          .toPromise()
+          .then((users) => {
+            expect(users).toEqual(USERS);
+
+            users.forEach(function(user) {
+              expect(user.username).toEqual('foo');
+            });
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
#### Description
This PR adds the ability to discover users using the SDK.

#### Changes
- Override the `find()` function in the `UserStore` class to use the user discover api.
- Add a static `find()` function to the `User` class that proxy calls to the `UserStore`.
- Default all options to an empty object on the `User` class. Fixes MLIBZ-1579.
- Add unit tests for user discovery.
