### PR TITLE
MLIBZ-1604: Update a user causes 401 on subsequent API requests

### DIFF
--- a/src/datastore/src/userstore.js
+++ b/src/datastore/src/userstore.js
@@ -51,7 +51,7 @@ class UserStore extends NetworkStore {
     }
 
     if (!data._id) {
-      return Promise.ject(new KinveyError('User must have an _id.'));
+      return Promise.reject(new KinveyError('User must have an _id.'));
     }
 
     return super.update(data, options);

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -691,18 +691,17 @@ export default class User {
   update(data, options) {
     data = assign(this.data, data);
     return store.update(data, options)
-      .then(() => {
-        this.data = data;
-        return this.isActive();
-      })
-      .then((isActive) => {
-        if (isActive) {
-          return CacheRequest.setActiveUser(this.client, this.data);
+      .then((data) => {
+        if (this.isActive() === true) {
+          return CacheRequest.setActiveUser(this.client, data);
         }
 
-        return this;
+        return data;
       })
-      .then(() => this);
+      .then((data) => {
+        this.data = data;
+        return this;
+      });
   }
 
   /**

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -711,7 +711,7 @@ export default class User {
    * @param {Object} [options] Options
    * @return {Promise<User>} The user.
    */
-  static update(data, options) {
+  static update(data, options = {}) {
     const activeUser = User.getActiveUser(options.client);
 
     if (isDefined(activeUser)) {

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -692,7 +692,7 @@ export default class User {
     data = assign(this.data, data);
     return store.update(data, options)
       .then((data) => {
-        if (this.isActive() === true) {
+        if (this.isActive()) {
           return CacheRequest.setActiveUser(this.client, data);
         }
 

--- a/src/request/src/network.js
+++ b/src/request/src/network.js
@@ -400,7 +400,7 @@ export class KinveyRequest extends NetworkRequest {
             throw error;
           }
 
-          const socialIdentities = activeUser._socialIdentity;
+          const socialIdentities = isDefined(activeUser._socialIdentity) ? activeUser._socialIdentity : {};
           const sessionKey = Object.keys(socialIdentities)
             .find(sessionKey => socialIdentities[sessionKey].identity === SocialIdentity.MobileIdentityConnect);
           const session = socialIdentities[sessionKey];

--- a/test/unit/entity/user.test.js
+++ b/test/unit/entity/user.test.js
@@ -354,7 +354,9 @@ describe('User', function() {
           return user.update({ email: email })
             .then(() => {
               expect(user.data).toEqual(responseData);
+              expect(user._kmd.authtoken).toEqual(responseData._kmd.authtoken);
               expect(activeUser.data).toNotEqual(responseData);
+              expect(activeUser._kmd.authtoken).toNotEqual(responseData._kmd.authtoken);
             });
         });
     });

--- a/test/unit/entity/user.test.js
+++ b/test/unit/entity/user.test.js
@@ -4,6 +4,7 @@ import { ActiveUserError, InvalidCredentialsError, KinveyError } from 'src/error
 import { TestUser } from '../mocks';
 import expect from 'expect';
 import nock from 'nock';
+import assign from 'lodash/assign';
 const rpcNamespace = process.env.KINVEY_RPC_NAMESPACE || 'rpc';
 
 describe('User', function() {
@@ -298,6 +299,64 @@ describe('User', function() {
 
       const response = await User.forgotUsername(email);
       expect(response).toEqual({});
+    });
+  });
+
+  describe('update()', function() {
+    it('should throw an error if the user does not have an _id', function() {
+      const user = new User({ email: randomString() });
+      return user.update({ email: randomString })
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+          expect(error.message).toEqual('User must have an _id.');
+        });
+    });
+
+    it('should update the active user', function() {
+      return TestUser.logout()
+        .then(() => {
+          return TestUser.login(randomString(), randomString());
+        })
+        .then((user) => {
+          const email = randomString();
+          const requestData = assign(user.data, { email: email })
+          const responseData = assign(requestData, { _kmd: { authtoken: randomString() } });
+
+          // Kinvey API response
+          nock(this.client.apiHostname, { encodedQueryParams: true })
+            .put(`${user.pathname}/${user._id}`, requestData)
+            .reply(200, responseData);
+
+          return user.update({ email: email })
+            .then(() => {
+              const activeUser = User.getActiveUser();
+              expect(activeUser.data).toEqual(responseData);
+            });
+        });
+    });
+
+    it('should update a user and not the active user', function() {
+      return TestUser.logout()
+        .then(() => {
+          return TestUser.login(randomString(), randomString());
+        })
+        .then((activeUser) => {
+          const user = new User({ _id: randomString(), email: randomString() });
+          const email = randomString();
+          const requestData = assign(user.data, { email: email })
+          const responseData = assign(requestData, { _kmd: { authtoken: randomString() } });
+
+          // Kinvey API response
+          nock(this.client.apiHostname, { encodedQueryParams: true })
+            .put(`${user.pathname}/${user._id}`, requestData)
+            .reply(200, responseData);
+
+          return user.update({ email: email })
+            .then(() => {
+              expect(user.data).toEqual(responseData);
+              expect(activeUser.data).toNotEqual(responseData);
+            });
+        });
     });
   });
 });


### PR DESCRIPTION
#### Description
This PR updates the active user data if a `PUT` request is made to update the user on the backend.

#### Changes
- Update active user data with data returned from `PUT` request made on the active user to the backend.
- Add unit tests for updating a user.
