### PR TITLE
MLIBZ-1576: Kinvey V3 add acl to individual entity error

### DIFF
--- a/src/entity/src/acl.js
+++ b/src/entity/src/acl.js
@@ -1,6 +1,5 @@
 import { KinveyError } from 'src/errors';
 import { isDefined } from 'src/utils';
-import cloneDeep from 'lodash/cloneDeep';
 import isPlainObject from 'lodash/isPlainObject';
 import isArray from 'lodash/isArray';
 import assign from 'lodash/assign';
@@ -13,8 +12,8 @@ import assign from 'lodash/assign';
  * var acl = new Kinvey.Acl(entity);
  */
 export default class Acl {
-  constructor(entity = {}) {
-    if (!isPlainObject(entity)) {
+  constructor(entity) {
+    if (isPlainObject(entity) === false) {
       throw new KinveyError('entity argument must be an object');
     }
 
@@ -24,7 +23,8 @@ export default class Acl {
      * @private
      * @type {Object}
      */
-    this.acl = cloneDeep(entity._acl);
+    entity._acl = entity._acl || {};
+    this.acl = entity._acl;
   }
 
   get creator() {

--- a/src/entity/src/acl.js
+++ b/src/entity/src/acl.js
@@ -18,48 +18,48 @@ export default class Acl {
     }
 
     /**
-     * The kmd properties.
+     * The entity.
      *
      * @private
      * @type {Object}
      */
     entity._acl = entity._acl || {};
-    this.acl = entity._acl;
+    this.entity = entity;
   }
 
   get creator() {
-    return this.acl.creator;
+    return this.entity._acl.creator;
   }
 
   get readers() {
-    return isArray(this.acl.r) ? this.acl.r : [];
+    return isArray(this.entity._acl.r) ? this.entity._acl.r : [];
   }
 
   get writers() {
-    return isArray(this.acl.w) ? this.acl.w : [];
+    return isArray(this.entity._acl.w) ? this.entity._acl.w : [];
   }
 
   get readerGroups() {
-    return isDefined(this.acl.groups) && isArray(this.acl.groups.r) ? this.acl.groups.r : [];
+    return isDefined(this.entity._acl.groups) && isArray(this.entity._acl.groups.r) ? this.entity._acl.groups.r : [];
   }
 
   get writerGroups() {
-    return isDefined(this.acl.groups) && isArray(this.acl.groups.w) ? this.acl.groups.w : [];
+    return isDefined(this.entity._acl.groups) && isArray(this.entity._acl.groups.w) ? this.entity._acl.groups.w : [];
   }
 
   set globallyReadable(gr) {
     if (gr === true) {
-      this.acl.gr = gr;
+      this.entity._acl.gr = gr;
     } else {
-      this.acl.gr = false;
+      this.entity._acl.gr = false;
     }
   }
 
   set globallyWritable(gw) {
     if (gw === true) {
-      this.acl.gw = gw;
+      this.entity._acl.gw = gw;
     } else {
-      this.acl.gw = false;
+      this.entity._acl.gw = false;
     }
   }
 
@@ -70,7 +70,7 @@ export default class Acl {
       r.push(user);
     }
 
-    this.acl.r = r;
+    this.entity._acl.r = r;
     return this;
   }
 
@@ -81,7 +81,7 @@ export default class Acl {
       groups.push(group);
     }
 
-    this.acl.groups = assign({}, this.acl.groups, { r: groups });
+    this.entity._acl.groups = assign({}, this.entity._acl.groups, { r: groups });
     return this;
   }
 
@@ -92,7 +92,7 @@ export default class Acl {
       w.push(user);
     }
 
-    this.acl.w = w;
+    this.entity._acl.w = w;
     return this;
   }
 
@@ -103,21 +103,21 @@ export default class Acl {
       groups.push(group);
     }
 
-    this.acl.groups = assign({}, this.acl.groups, { w: groups });
+    this.entity._acl.groups = assign({}, this.entity._acl.groups, { w: groups });
     return this;
   }
 
   isGloballyReadable() {
-    if (this.acl.gr === true) {
-      return this.acl.gr;
+    if (this.entity._acl.gr === true) {
+      return this.entity._acl.gr;
     }
 
     return false;
   }
 
   isGloballyWritable() {
-    if (this.acl.gw === true) {
-      return this.acl.gw;
+    if (this.entity._acl.gw === true) {
+      return this.entity._acl.gw;
     }
 
     return false;
@@ -131,7 +131,7 @@ export default class Acl {
       r.splice(index, 1);
     }
 
-    this.acl.r = r;
+    this.entity._acl.r = r;
     return this;
   }
 
@@ -143,7 +143,7 @@ export default class Acl {
       groups.splice(index, 1);
     }
 
-    this.acl.groups = assign({}, this.acl.groups, { r: groups });
+    this.entity._acl.groups = assign({}, this.entity._acl.groups, { r: groups });
     return this;
   }
 
@@ -155,7 +155,7 @@ export default class Acl {
       w.splice(index, 1);
     }
 
-    this.acl.w = w;
+    this.entity._acl.w = w;
     return this;
   }
 
@@ -167,11 +167,11 @@ export default class Acl {
       groups.splice(index, 1);
     }
 
-    this.acl.groups = assign({}, this.acl.groups, { w: groups });
+    this.entity._acl.groups = assign({}, this.entity._acl.groups, { w: groups });
     return this;
   }
 
   toPlainObject() {
-    return this.acl;
+    return this.entity._acl;
   }
 }

--- a/src/entity/src/metadata.js
+++ b/src/entity/src/metadata.js
@@ -1,14 +1,12 @@
 import { KinveyError } from 'src/errors';
 import { isDefined } from 'src/utils';
-import cloneDeep from 'lodash/clone';
 import isPlainObject from 'lodash/isPlainObject';
-const kmdAttribute = process.env.KINVEY_KMD_ATTRIBUTE || '_kmd';
 
 /**
  * The Metadata class is used to as a wrapper for accessing the `_kmd` properties of an entity.
  */
 export default class Metadata {
-  constructor(entity = {}) {
+  constructor(entity) {
     if (!isPlainObject(entity)) {
       throw new KinveyError('entity argument must be an object');
     }
@@ -19,7 +17,7 @@ export default class Metadata {
      * @private
      * @type {Object}
      */
-    this.kmd = cloneDeep(entity[kmdAttribute] || {});
+    this.kmd = entity._kmd || {};
   }
 
   get createdAt() {
@@ -59,7 +57,7 @@ export default class Metadata {
   }
 
   isLocal() {
-    return !!this.kmd.local;
+    return this.kmd.local === true;
   }
 
   toPlainObject() {

--- a/src/entity/src/metadata.js
+++ b/src/entity/src/metadata.js
@@ -7,22 +7,23 @@ import isPlainObject from 'lodash/isPlainObject';
  */
 export default class Metadata {
   constructor(entity) {
-    if (!isPlainObject(entity)) {
+    if (isPlainObject(entity) === false) {
       throw new KinveyError('entity argument must be an object');
     }
 
     /**
-     * The kmd properties.
+     * The entity.
      *
      * @private
      * @type {Object}
      */
-    this.kmd = entity._kmd || {};
+    entity._kmd = entity._kmd || {};
+    this.entity = entity;
   }
 
   get createdAt() {
-    if (this.kmd.ect) {
-      return new Date(this.kmd.ect);
+    if (this.entity._kmd.ect) {
+      return new Date(this.entity._kmd.ect);
     }
 
     return undefined;
@@ -33,16 +34,16 @@ export default class Metadata {
   }
 
   get emailVerification() {
-    if (isDefined(this.kmd.emailVerification)) {
-      return this.kmd.emailVerification.status;
+    if (isDefined(this.entity._kmd.emailVerification)) {
+      return this.entity._kmd.emailVerification.status;
     }
 
     return undefined;
   }
 
   get lastModified() {
-    if (this.kmd.lmt) {
-      return new Date(this.kmd.lmt);
+    if (this.entity._kmd.lmt) {
+      return new Date(this.entity._kmd.lmt);
     }
 
     return undefined;
@@ -53,14 +54,14 @@ export default class Metadata {
   }
 
   get authtoken() {
-    return this.kmd.authtoken;
+    return this.entity._kmd.authtoken;
   }
 
   isLocal() {
-    return this.kmd.local === true;
+    return this.entity._kmd.local === true;
   }
 
   toPlainObject() {
-    return this.kmd;
+    return this.entity._kmd;
   }
 }

--- a/test/unit/entity/acl.test.js
+++ b/test/unit/entity/acl.test.js
@@ -12,14 +12,14 @@ describe('Acl', function() {
       }).toThrow(KinveyError, /entity argument must be an object/);
     });
 
-    it('should create empty acl when the entity does not contain an acl property', function() {
+    it('should create an empty acl when the entity does not contain an _acl property', function() {
       const entity = {};
       const acl = new Acl(entity);
       expect(acl.toPlainObject()).toEqual({});
       expect(entity._acl).toEqual({});
     });
 
-    it('should create use acl property on the entity', function() {
+    it('should use the _acl property on the entity', function() {
       const aclProp = { r: [] };
       const entity = { _acl: aclProp };
       const acl = new Acl(entity);

--- a/test/unit/entity/acl.test.js
+++ b/test/unit/entity/acl.test.js
@@ -1,8 +1,33 @@
 import { Acl } from 'src/entity';
 import { randomString } from 'src/utils';
+import { KinveyError } from 'src/errors';
 import expect from 'expect';
 
 describe('Acl', function() {
+  describe('constructor', function() {
+    it('should throw an error if an entity is not provided', function() {
+      expect(() => {
+        const acl = new Acl();
+        return acl;
+      }).toThrow(KinveyError, /entity argument must be an object/);
+    });
+
+    it('should create empty acl when the entity does not contain an acl property', function() {
+      const entity = {};
+      const acl = new Acl(entity);
+      expect(acl.toPlainObject()).toEqual({});
+      expect(entity._acl).toEqual({});
+    });
+
+    it('should create use acl property on the entity', function() {
+      const aclProp = { r: [] };
+      const entity = { _acl: aclProp };
+      const acl = new Acl(entity);
+      expect(acl.toPlainObject()).toEqual(aclProp);
+      expect(entity._acl).toEqual(aclProp);
+    });
+  });
+
   describe('creator', function() {
     it('should be creator value', function() {
       const creator = randomString();
@@ -149,10 +174,12 @@ describe('Acl', function() {
     });
 
     it('should add a reader', function() {
+      const entity = { _acl: {} };
       const user = randomString();
-      const acl = new Acl({ _acl: {} });
+      const acl = new Acl(entity);
       acl.addReader(user);
       expect(acl.readers).toEqual([user]);
+      expect(entity._acl.r).toEqual([user]);
     });
   });
 

--- a/test/unit/entity/metadata.test.js
+++ b/test/unit/entity/metadata.test.js
@@ -16,7 +16,7 @@ describe('Metadata', function() {
       const entity = {};
       const metadata = new Metadata(entity);
       expect(metadata.toPlainObject()).toEqual({});
-      expect(entity._kmd).toEqual(undefined);
+      expect(entity._kmd).toEqual({});
     });
 
     it('should use the _kmd property on the entity', function() {

--- a/test/unit/entity/metadata.test.js
+++ b/test/unit/entity/metadata.test.js
@@ -1,8 +1,33 @@
 import { Metadata } from 'src/entity';
 import { randomString } from 'src/utils';
+import { KinveyError } from 'src/errors';
 import expect from 'expect';
 
 describe('Metadata', function() {
+  describe('constructor', function() {
+    it('should throw an error if an entity is not provided', function() {
+      expect(() => {
+        const metadata = new Metadata();
+        return metadata;
+      }).toThrow(KinveyError, /entity argument must be an object/);
+    });
+
+    it('should create an empty metadata when the entity does not contain an _kmd property', function() {
+      const entity = {};
+      const metadata = new Metadata(entity);
+      expect(metadata.toPlainObject()).toEqual({});
+      expect(entity._kmd).toEqual(undefined);
+    });
+
+    it('should use the _kmd property on the entity', function() {
+      const kmdProp = { lmt: randomString() };
+      const entity = { _kmd: kmdProp };
+      const metadata = new Metadata(entity);
+      expect(metadata.toPlainObject()).toEqual(kmdProp);
+      expect(entity._kmd).toEqual(kmdProp);
+    });
+  });
+
   describe('createdAt', function() {
     it('should return undefined for entity create time', function() {
       const metadata = new Metadata({ _kmd: {} });


### PR DESCRIPTION
#### Description
This PR fixes errors when trying to use `Kinvey.Acl` and `Kinvey.Metadata` with invalid objects.

#### Changes
- Create an `_acl` property when a provided entity to `Kinvey.Acl` does not contain an `_acl` property.
- Create an `_kmd` property when a provided entity to `Kinvey.Metadata` does not contain an `_kmd` property.
- Don't default entities to an empty object for `Kinvey.Acl` and `Kinvey.Metadata`.
- Update/Add related tests for `Kinvey.Acl` and `Kinvey.Metadata`.