### PR TITLE
Remove the use of es6-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "append-query": "1.1.0",
     "core-js": "2.4.1",
     "es6-error": "3.2.0",
-    "es6-promise": "4.0.4",
     "fast-memory-cache": "2.0.4",
     "hellojs": "1.13.1",
     "local-storage": "1.4.2",

--- a/src/datastore/src/filestore.js
+++ b/src/datastore/src/filestore.js
@@ -8,7 +8,6 @@ import {
 import { KinveyError } from 'src/errors';
 import NetworkStore from './networkstore';
 import { Log } from 'src/utils';
-import Promise from 'es6-promise';
 import url from 'url';
 import map from 'lodash/map';
 import assign from 'lodash/assign';

--- a/src/datastore/src/networkstore.js
+++ b/src/datastore/src/networkstore.js
@@ -4,7 +4,6 @@ import Query from 'src/query';
 import Client from 'src/client';
 import { KinveyObservable, Log, isDefined } from 'src/utils';
 import Aggregation from 'src/aggregation';
-import Promise from 'es6-promise';
 import isString from 'lodash/isString';
 import url from 'url';
 import map from 'lodash/map';

--- a/src/datastore/src/sync.js
+++ b/src/datastore/src/sync.js
@@ -8,7 +8,6 @@ import {
 import { InsufficientCredentialsError, SyncError } from 'src/errors';
 import Client from 'src/client';
 import Query from 'src/query';
-import Promise from 'es6-promise';
 import url from 'url';
 import map from 'lodash/map';
 import result from 'lodash/result';

--- a/src/datastore/src/userstore.js
+++ b/src/datastore/src/userstore.js
@@ -3,7 +3,6 @@ import { KinveyError } from 'src/errors';
 import { KinveyObservable, isDefined } from '../../utils';
 import Query from '../../query';
 import NetworkStore from './networkstore';
-import Promise from 'es6-promise';
 import url from 'url';
 import isArray from 'lodash/isArray';
 const usersNamespace = process.env.KINVEY_USERS_NAMESPACE || 'user';

--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -6,7 +6,6 @@ import { KinveyError, NotFoundError, ActiveUserError } from 'src/errors';
 import DataStore, { UserStore as store } from 'src/datastore';
 import { Facebook, Google, LinkedIn, MobileIdentityConnect } from 'src/identity';
 import { Log, isDefined } from 'src/utils';
-import Promise from 'es6-promise';
 import url from 'url';
 import assign from 'lodash/assign';
 import result from 'lodash/result';

--- a/src/identity/src/facebook.js
+++ b/src/identity/src/facebook.js
@@ -4,7 +4,6 @@ import Identity from './identity';
 import { SocialIdentity } from './enums';
 import { KinveyError } from 'src/errors';
 import { randomString } from 'src/utils';
-import Promise from 'es6-promise';
 import assign from 'lodash/assign';
 import querystring from 'querystring';
 import url from 'url';

--- a/src/identity/src/identity.js
+++ b/src/identity/src/identity.js
@@ -1,6 +1,5 @@
 import Client from 'src/client';
 import { KinveyError } from 'src/errors';
-import Promise from 'es6-promise';
 import localStorage from 'local-storage';
 import assign from 'lodash/assign';
 let hello;

--- a/src/identity/src/mic.js
+++ b/src/identity/src/mic.js
@@ -3,7 +3,6 @@ import Identity from './identity';
 import { SocialIdentity } from './enums';
 import { AuthType, RequestMethod, KinveyRequest } from 'src/request';
 import { KinveyError, MobileIdentityConnectError } from 'src/errors';
-import Promise from 'es6-promise';
 import path from 'path';
 import url from 'url';
 import isString from 'lodash/isString';

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -7,7 +7,6 @@ import localStorage from 'local-storage';
 import { KinveyError } from 'src/errors';
 import Query from 'src/query';
 import Aggregation from 'src/aggregation';
-import Promise from 'es6-promise';
 import { isDefined } from 'src/utils';
 import { CacheRack } from './rack';
 const usersNamespace = process.env.KINVEY_USERS_NAMESPACE || 'user';

--- a/src/request/src/deltafetch.js
+++ b/src/request/src/deltafetch.js
@@ -5,7 +5,6 @@ import Response, { StatusCode } from './response';
 import { KinveyError, NotFoundError } from 'src/errors';
 import { isDefined } from 'src/utils';
 import Query from 'src/query';
-import Promise from 'es6-promise';
 import keyBy from 'lodash/keyBy';
 import reduce from 'lodash/reduce';
 import result from 'lodash/result';

--- a/src/request/src/middleware/src/http.js
+++ b/src/request/src/middleware/src/http.js
@@ -1,5 +1,4 @@
 import Middleware from './middleware';
-import Promise from 'es6-promise';
 import httpRequest from 'request';
 import { isDefined } from 'src/utils';
 import { NoNetworkConnectionError, TimeoutError } from 'src/errors';

--- a/src/request/src/middleware/src/middleware.js
+++ b/src/request/src/middleware/src/middleware.js
@@ -1,5 +1,4 @@
 import AsciiTree from './asciitree';
-import Promise from 'es6-promise';
 
 export default class Middleware {
   constructor(name = 'Middleware') {

--- a/src/request/src/middleware/src/parse.js
+++ b/src/request/src/middleware/src/parse.js
@@ -1,5 +1,4 @@
 import Middleware from './middleware';
-import Promise from 'es6-promise';
 
 export default class ParseMiddleware extends Middleware {
   constructor(name = 'Parse Middleware') {

--- a/src/request/src/middleware/src/serialize.js
+++ b/src/request/src/middleware/src/serialize.js
@@ -1,5 +1,4 @@
 import Middleware from './middleware';
-import Promise from 'es6-promise';
 
 export default class SerializeMiddleware extends Middleware {
   constructor(name = 'Serialize Middleware') {

--- a/src/request/src/middleware/src/storage/index.js
+++ b/src/request/src/middleware/src/storage/index.js
@@ -1,6 +1,5 @@
 import { NotFoundError } from 'src/errors';
 import MemoryAdapter from './src/memory';
-import Promise from 'es6-promise';
 import Queue from 'promise-queue';
 import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';

--- a/src/request/src/middleware/src/storage/src/memory.js
+++ b/src/request/src/middleware/src/storage/src/memory.js
@@ -1,6 +1,5 @@
 import { NotFoundError } from 'src/errors';
 import MemoryCache from 'fast-memory-cache';
-import Promise from 'es6-promise';
 import keyBy from 'lodash/keyBy';
 import forEach from 'lodash/forEach';
 import values from 'lodash/values';

--- a/src/request/src/network.js
+++ b/src/request/src/network.js
@@ -7,7 +7,6 @@ import Aggregation from 'src/aggregation';
 import { isDefined } from 'src/utils';
 import { InvalidCredentialsError, NoActiveUserError, KinveyError } from 'src/errors';
 import { SocialIdentity } from 'src/identity';
-import Promise from 'es6-promise';
 import url from 'url';
 import qs from 'qs';
 import appendQuery from 'append-query';

--- a/src/request/src/rack.js
+++ b/src/request/src/rack.js
@@ -4,7 +4,6 @@ import Middleware, {
   ParseMiddleware,
   SerializeMiddleware
 } from './middleware';
-import Promise from 'es6-promise';
 import reduce from 'lodash/reduce';
 import isFunction from 'lodash/isFunction';
 import { isDefined } from 'src/utils';

--- a/src/utils/src/observable.js
+++ b/src/utils/src/observable.js
@@ -1,5 +1,4 @@
 import { Observable } from 'rxjs/Observable';
-import Promise from 'es6-promise';
 
 /**
  * @private

--- a/test/unit/mocks/src/user.js
+++ b/test/unit/mocks/src/user.js
@@ -1,6 +1,5 @@
 import { User } from 'src/entity';
 import { randomString } from 'src/utils';
-import Promise from 'es6-promise';
 import nock from 'nock';
 import url from 'url';
 


### PR DESCRIPTION
#### Description
This PR removes the use of the es6-promise dependency. NodeJs has [basic support](http://node.green/#Promise) for Promises all the way back to 0.12.18. All other shims can include a shim to add Promise support to the bundle with webpack.

#### Changes
- Remove use of es6-promise.