### PR TITLE
MLIBZ-1089: Sending a POST request with `??` causes the request to be sent as a GET with Backbone

### DIFF
--- a/src/shims/backbone/persistence/net.js
+++ b/src/shims/backbone/persistence/net.js
@@ -164,7 +164,6 @@ var BackboneAjax = {
     var xhr = options.xhr = Backbone.ajax({
       complete    : onComplete,
       data        : body,
-      dataType    : 'json',
       headers     : headers,
       mimeType    : options.file ? 'text/plain; charset=x-user-defined' : null,
       processData : false,


### PR DESCRIPTION
#### Description
Issue describe here https://bugs.jquery.com/ticket/8417. By specifying `dataType: json` when sending a `POST` request using jQuery ajax that contains `??` in the body, the request is transformed to a `GET` request.

#### Changes
- Remove `dataType: json`
