### PR TITLE
Use tls: true as default when finding files

### DIFF
--- a/src/datastore/src/filestore.js
+++ b/src/datastore/src/filestore.js
@@ -75,7 +75,11 @@ class FileStore extends NetworkStore {
    * });
    */
   find(query, options = {}) {
-    options.query = options.query || {};
+    // Set defaults for options
+    options = assign({
+      query: {},
+      tls: true
+    }, options);
     options.query.tls = options.tls === true;
 
     if (isNumber(options.ttl)) {


### PR DESCRIPTION
#### Description
We should always default to using `https` urls by default when looking up files.

#### Changes
- use `tls: true` as default for finding files