### PR TITLE
Sync with query

### DIFF
--- a/src/datastore/src/cachestore.js
+++ b/src/datastore/src/cachestore.js
@@ -830,7 +830,7 @@ export default class CacheStore extends NetworkStore {
    */
   sync(query, options) {
     options = assign({ useDeltaFetch: this.useDeltaFetch }, options);
-    return this.push(null, options)
+    return this.push(query, options)
       .then((push) => {
         const promise = this.pull(query, options)
           .then((pull) => {

--- a/src/datastore/src/cachestore.js
+++ b/src/datastore/src/cachestore.js
@@ -85,11 +85,11 @@ export default class CacheStore extends NetworkStore {
 
           if (syncAutomatically === true) {
             // Attempt to push any pending sync data before fetching from the network.
-            return this.pendingSyncCount(null, options)
+            return this.pendingSyncCount(query, options)
               .then((syncCount) => {
                 if (syncCount > 0) {
-                  return this.push(null, options)
-                    .then(() => this.pendingSyncCount(null, options));
+                  return this.push(query, options)
+                    .then(() => this.pendingSyncCount(query, options));
                 }
 
                 return syncCount;
@@ -182,10 +182,13 @@ export default class CacheStore extends NetworkStore {
 
           if (syncAutomatically === true) {
             // Attempt to push any pending sync data before fetching from the network.
-            return this.pendingSyncCount(null, options)
+            const query = new Query();
+            query.equalTo('_id', id);
+            return this.pendingSyncCount(query, options)
               .then((syncCount) => {
                 if (syncCount > 0) {
-                  return this.push(null, options).then(() => this.pendingSyncCount(null, options));
+                  return this.push(query, options)
+                    .then(() => this.pendingSyncCount(query, options));
                 }
 
                 return syncCount;
@@ -345,10 +348,11 @@ export default class CacheStore extends NetworkStore {
 
           if (syncAutomatically === true) {
             // Attempt to push any pending sync data before fetching from the network.
-            return this.pendingSyncCount(null, options)
+            return this.pendingSyncCount(query, options)
               .then((syncCount) => {
                 if (syncCount > 0) {
-                  return this.push(null, options).then(() => this.pendingSyncCount(null, options));
+                  return this.push(query, options)
+                    .then(() => this.pendingSyncCount(query, options));
                 }
 
                 return syncCount;

--- a/src/datastore/src/sync.js
+++ b/src/datastore/src/sync.js
@@ -15,6 +15,7 @@ import {
 import { InsufficientCredentialsError, SyncError } from 'src/errors';
 import Client from 'src/client';
 import Query from 'src/query';
+import { isDefined } from 'src/utils';
 
 const appdataNamespace = process.env.KINVEY_DATASTORE_NAMESPACE || 'appdata';
 const syncCollectionName = process.env.KINVEY_SYNC_COLLECTION_NAME || 'kinvey_sync';
@@ -261,6 +262,7 @@ export default class SyncManager {
   push(query, options = {}) {
     const batchSize = 100;
     let i = 0;
+    let promise = Promise.resolve(null);
 
     // Don't push data to the backend if we are in the middle
     // of already pushing data
@@ -272,8 +274,38 @@ export default class SyncManager {
     // Set pushInProgress to true
     pushInProgress = true;
 
-    // Get the pending sync items
-    return this.find(query)
+    if (isDefined(query)) {
+      if (!(query instanceof Query)) {
+        query = new Query(result(query, 'toJSON', query));
+      }
+
+      const request = new CacheRequest({
+        method: RequestMethod.GET,
+        url: url.format({
+          protocol: this.client.protocol,
+          host: this.client.host,
+          pathname: this.backendPathname
+        }),
+        query: query,
+        properties: options.properties,
+        timeout: options.timeout,
+        client: this.client
+      });
+      promise = request.execute()
+        .then(response => response.data);
+    }
+
+    return promise
+      .then((entities) => {
+        if (isDefined(entities)) {
+          const syncQuery = new Query();
+          syncQuery.contains('entityId', map(entities, entity => entity._id));
+          return this.find(syncQuery);
+        }
+
+        // Get the pending sync items
+        return this.find();
+      })
       .then((syncEntities) => {
         if (syncEntities.length > 0) {
           // Sync the entities in batches to prevent exhausting

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -1,4 +1,4 @@
-import { SyncStore } from 'src/datastore';
+import { CacheStore, SyncStore } from 'src/datastore';
 import Client from 'src/client';
 import Query from 'src/query';
 import { KinveyError, NotFoundError } from 'src/errors';
@@ -1090,39 +1090,51 @@ describe('SyncStore', function() {
     });
 
     it('should sync only entities matching the query', function() {
-      const store = new SyncStore(collection);
-      return store.save([{ title: 'foo' }, { title: 'bar' }])
+      const syncStore = new SyncStore(collection);
+      return syncStore.save([{ title: 'foo' }, { title: 'bar' }])
         .then((entities) => {
-          return store.syncCount()
+          return syncStore.syncCount()
             .then((count) => {
               expect(count).toEqual(2);
               return entities;
             });
         })
         .then((entities) => {
-          nock(store.client.baseUrl)
-            .post(store.pathname, () => true)
+          nock(syncStore.client.baseUrl)
+            .post(syncStore.pathname, () => true)
             .query(true)
             .reply(201, entities[0]);
 
-          nock(store.client.baseUrl)
-            .get(store.pathname, () => true)
+          nock(syncStore.client.baseUrl)
+            .get(syncStore.pathname, () => true)
             .query(true)
             .reply(200, [entities[0]]);
 
           const query = new Query();
           query.equalTo('title', 'foo');
-          return store.sync(query)
+          return syncStore.sync(query)
             .then((result) => {
               expect(result.pull).toEqual([entities[0]]);
               expect(result.push).toEqual([
                 { _id: entities[0]._id, entity: entities[0] }
               ]);
-              return store.syncCount();
+              return syncStore.syncCount();
+            })
+            .then((count) => {
+              expect(count).toEqual(1);
+
+              const cacheStore = new CacheStore(collection);
+
+              nock(cacheStore.client.baseUrl)
+                .get(cacheStore.pathname, () => true)
+                .query(true)
+                .reply(200, [entities[0]]);
+
+              return cacheStore.find(query).toPromise();
+            })
+            .then((findEntities) => {
+              expect(findEntities).toEqual([entities[0]]);
             });
-        })
-        .then((count) => {
-          expect(count).toEqual(1);
         });
     });
   });


### PR DESCRIPTION
#### Description
This PR allows a user to push only entities in the sync table matching the provided query.

#### Changes
- Find entities that match the query provided before pushing entities to the backend.
- Add a unit test to verify only entities matching the query are pushed.
