### PR TITLE
MLIBZ-1779: Allow sync to push on different collections at the same time

### DIFF
--- a/src/datastore/src/sync.js
+++ b/src/datastore/src/sync.js
@@ -18,7 +18,7 @@ import Query from 'src/query';
 
 const appdataNamespace = process.env.KINVEY_DATASTORE_NAMESPACE || 'appdata';
 const syncCollectionName = process.env.KINVEY_SYNC_COLLECTION_NAME || 'kinvey_sync';
-let pushInProgress = false;
+const pushInProgress = new Map();
 
 /**
  * @private
@@ -264,13 +264,13 @@ export default class SyncManager {
 
     // Don't push data to the backend if we are in the middle
     // of already pushing data
-    if (pushInProgress) {
+    if (pushInProgress.get(this.collection) === true) {
       return Promise.reject(new SyncError('Data is already being pushed to the backend.'
         + ' Please wait for it to complete before pushing new data to the backend.'));
     }
 
     // Set pushInProgress to true
-    pushInProgress = true;
+    pushInProgress.set(this.collection, true);
 
     // Get the pending sync items
     return this.find(query)
@@ -591,12 +591,12 @@ export default class SyncManager {
       })
       .then((result) => {
         // Set pushInProgress to false
-        pushInProgress = false;
+        pushInProgress.set(this.collection, false);
         return result;
       })
       .catch((error) => {
         // Set pushInProgress to false
-        pushInProgress = false;
+        pushInProgress.set(this.collection, false);
         throw error;
       });
   }

--- a/test/datastore/sync.test.js
+++ b/test/datastore/sync.test.js
@@ -232,5 +232,33 @@ describe('Sync', function () {
           return sync.push();
         });
     });
+
+    it('should push when an existing push is in progress on a different collection', function(done) {
+      const sync1 = new SyncManager(collection);
+      var entity1 = { _id: randomString() };
+      var promise = sync1.addDeleteOperation(entity1)
+        .then(() => {
+          // Kinvey API Response
+          nock(sync1.client.baseUrl)
+            .delete(`${sync1.backendPathname}/${entity1._id}`, () => true)
+            .query(true)
+            .delay(1000) // Delay the response for 1 second
+            .reply(204);
+
+          // Sync
+          sync1.push()
+            .then(() => promise.should.be.fulfilled)
+            .then(() => done())
+            .catch(done);
+
+          // Add second sync operation
+          const sync2 = new SyncManager(randomString());
+          const entity2 = { _id: randomString() };
+          return sync2.addDeleteOperation(entity2)
+            .then(() => {
+              return sync2.push();
+          });
+        });
+    });
   });
 });


### PR DESCRIPTION
#### Description
This PR allows sync to push entities to the backend simultaneously on different collections. If a sync push operation is attempted on a collection while one already is in progress for that same collection for then it will be rejected.

#### Changes
- Make `pushInProgress` flag a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) that uses the collection as a key.
- Add a test to ensure that a sync push operation can be made at the same time on two different collections.
