### PR TITLE
A function to overwrite Popup class

### DIFF
--- a/src/entity/src/user.js
+++ b/src/entity/src/user.js
@@ -945,4 +945,11 @@ export default class User {
   static restore(id, options = {}) {
     return store.restore(id, options);
   }
+
+  /**
+   * @private
+   */
+  static usePopupClass(popupClass) {
+    MobileIdentityConnect.usePopupClass(popupClass);
+  }
 }

--- a/src/identity/src/mic.js
+++ b/src/identity/src/mic.js
@@ -5,13 +5,15 @@ import isString from 'lodash/isString';
 
 import { AuthType, RequestMethod, KinveyRequest } from 'src/request';
 import { KinveyError, MobileIdentityConnectError } from 'src/errors';
-import Popup from './popup';
+import { isDefined } from 'src/utils';
+import CorePopup from './popup';
 import Identity from './identity';
 import { SocialIdentity } from './enums';
 
 const authPathname = process.env.KINVEY_MIC_AUTH_PATHNAME || '/oauth/auth';
 const tokenPathname = process.env.KINVEY_MIC_TOKEN_PATHNAME || '/oauth/token';
 const invalidatePathname = process.env.KINVEY_MIC_INVALIDATE_PATHNAME || '/oauth/invalidate';
+let Popup = CorePopup;
 
 /**
  * Enum for Mobile Identity Connect authorization grants.
@@ -258,5 +260,14 @@ export class MobileIdentityConnect extends Identity {
       properties: options.properties
     });
     return request.execute().then(response => response.data);
+  }
+
+  /**
+   * @private
+   */
+  static usePopupClass(popupClass) {
+    if (isDefined(popupClass)) {
+      Popup = popupClass;
+    }
   }
 }


### PR DESCRIPTION
#### Description
This PR adds a function to the `User` class to overwrite the Popup class used for Mobile Identity Connect. Right now, a build tool such as [Webpack](https://webpack.github.io/) is used to replace the popup class used at the time a bundle is generated. This PR would eliminate the need for this.

#### Changes
- Add `usePopupClass()` function to the `User` class.
