### PR TITLE
MLIBZ-1766: Add missing protocol for custom hostnames

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -42,15 +42,43 @@ export default class Client {
     }, options);
 
     if (options.apiHostname && isString(options.apiHostname)) {
-      const apiHostnameParsed = url.parse(options.apiHostname);
-      options.apiProtocol = apiHostnameParsed.protocol || 'https:';
-      options.apiHost = apiHostnameParsed.host;
+      let apiHostname = options.apiHostname;
+
+      if (/^https?:\/\//i.test(apiHostname) === false) {
+        apiHostname = `https://${apiHostname}`;
+      }
+
+      const apiHostnameParsed = url.parse(apiHostname);
+
+      /**
+       * @type {string}
+       */
+      this.apiProtocol = apiHostnameParsed.protocol;
+
+      /**
+       * @type {string}
+       */
+      this.apiHost = apiHostnameParsed.host;
     }
 
     if (options.micHostname && isString(options.micHostname)) {
-      const micHostnameParsed = url.parse(options.micHostname);
-      options.micProtocol = micHostnameParsed.protocol || 'https:';
-      options.micHost = micHostnameParsed.host;
+      let micHostname = options.micHostname;
+
+      if (/^https?:\/\//i.test(micHostname) === false) {
+        micHostname = `https://${micHostname}`;
+      }
+
+      const micHostnameParsed = url.parse(micHostname);
+
+      /**
+       * @type {string}
+       */
+      this.micProtocol = micHostnameParsed.protocol;
+
+      /**
+       * @type {string}
+       */
+      this.micHost = micHostnameParsed.host;
     }
 
     if (options.liveServiceHostname && isString(options.liveServiceHostname)) {
@@ -58,26 +86,6 @@ export default class Client {
       options.liveServiceProtocol = liveServiceHostnameParsed.protocol || 'https:';
       options.liveServiceHost = liveServiceHostnameParsed.host;
     }
-
-    /**
-     * @type {string}
-     */
-    this.apiProtocol = options.apiProtocol;
-
-    /**
-     * @type {string}
-     */
-    this.apiHost = options.apiHost;
-
-    /**
-     * @type {string}
-     */
-    this.micProtocol = options.micProtocol;
-
-    /**
-     * @type {string}
-     */
-    this.micHost = options.micHost;
 
     /**
      * @type {string}

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -13,16 +13,40 @@ describe('Client', () => {
       expect(client.liveServiceHostname).toEqual('https://kls.kinvey.com');
     });
 
-    it('should be able to provide custom apiHostname', () => {
+    it('should be able to provide custom apiHostname with protocol https:', () => {
       const apiHostname = 'https://mybaas.kinvey.com';
       const client = new Client({ apiHostname: apiHostname });
       expect(client.apiHostname).toEqual(apiHostname);
     });
 
-    it('should be able to provide custom micHostname', () => {
+    it('should be able to provide custom apiHostname with protocol http:', () => {
+      const apiHostname = 'http://mybaas.kinvey.com';
+      const client = new Client({ apiHostname: apiHostname });
+      expect(client.apiHostname).toEqual(apiHostname);
+    });
+
+    it('should be able to provide custom apiHostname without protocol', () => {
+      const apiHostname = 'myauth.kinvey.com';
+      const client = new Client({ apiHostname: apiHostname });
+      expect(client.apiHostname).toEqual(`https://${apiHostname}`);
+    });
+
+    it('should be able to provide custom micHostname with protocol https:', () => {
       const micHostname = 'https://myauth.kinvey.com';
       const client = new Client({ micHostname: micHostname });
       expect(client.micHostname).toEqual(micHostname);
+    });
+
+    it('should be able to provide custom micHostname with protocol http:', () => {
+      const micHostname = 'http://myauth.kinvey.com';
+      const client = new Client({ micHostname: micHostname });
+      expect(client.micHostname).toEqual(micHostname);
+    });
+
+    it('should be able to provide custom micHostname without protocol', () => {
+      const micHostname = 'myauth.kinvey.com';
+      const client = new Client({ micHostname: micHostname });
+      expect(client.micHostname).toEqual(`https://${micHostname}`);
     });
 
     it('should be able to provide custom liveServiceHostname', () => {


### PR DESCRIPTION
#### Description
Add a valid protocol to `apiHostname` and `micHostname` if either does not contain one.

#### Changes
- Use a regex to test for `https://` or `http://`

#### Tests
- Add tests to set `apiHostname` and `micHostname` to hostnames contains valid and invalid protocols.