### PR TITLE
Fix URL formation on Windows and URL symbols in custom ID breaking cache storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "request": "2.81.0",
     "rxjs": "5.2.0",
     "sift": "3.2.7",
-    "uid": "0.0.2"
+    "uid": "0.0.2",
+    "url-join": "2.0.2"
   },
   "devDependencies": {
     "app-module-path": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "request": "2.81.0",
     "rxjs": "5.2.0",
     "sift": "3.2.7",
-    "uid": "0.0.2",
-    "url-pattern": "1.0.3"
+    "uid": "0.0.2"
   },
   "devDependencies": {
     "app-module-path": "2.2.0",

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -1,8 +1,9 @@
 import Promise from 'es6-promise';
 import Queue from 'promise-queue';
-import UrlPattern from 'url-pattern';
 import url from 'url';
 import cloneDeep from 'lodash/cloneDeep';
+import identity from 'lodash/identity';
+import filter from 'lodash/filter';
 
 import Client from 'src/client';
 import { KinveyError } from 'src/errors';
@@ -70,11 +71,11 @@ export default class CacheRequest extends Request {
   set url(urlString) {
     super.url = urlString;
     const pathname = global.escape(url.parse(urlString).pathname);
-    const pattern = new UrlPattern('(/:namespace)(/)(:appKey)(/)(:collection)(/)(:entityId)(/)');
-    const { appKey, collection, entityId } = pattern.match(pathname) || {};
-    this.appKey = appKey;
-    this.collection = collection;
-    this.entityId = entityId;
+    const urlParts = filter(pathname.split('/'), identity);
+    // "pathname" has the following form "/namespace/appKey/collection/id"
+    this.appKey = urlParts[1];
+    this.collection = urlParts[2];
+    this.entityId = urlParts[3];
   }
 
   execute() {

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -70,8 +70,8 @@ export default class CacheRequest extends Request {
 
   set url(urlString) {
     super.url = urlString;
-    const pathname = global.escape(url.parse(urlString).pathname);
-    const urlParts = filter(pathname.split('/'), identity);
+    const pathname = global.decodeURIComponent(url.parse(urlString).pathname).replace(/^\//g, '');
+    const urlParts = pathname.split('/');
     // "pathname" has the following form "/namespace/appKey/collection/id"
     this.appKey = urlParts[1];
     this.collection = urlParts[2];

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -70,14 +70,7 @@ export default class CacheRequest extends Request {
 
   set url(urlString) {
     super.url = urlString;
-    let pathname = url.parse(urlString).pathname;
-
-    try {
-      pathname = global.decodeURIComponent(url.parse(urlString).pathname);
-    } catch (error) {
-      // Just catch the URI Malformed error
-    }
-
+    let pathname = global.decodeURIComponent(url.parse(urlString).pathname);
     const urlParts = pathname.replace(/^\//g, '').split('/');
     // "pathname" has the following form "/namespace/appKey/collection/id"
     this.appKey = urlParts[1];

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -70,8 +70,15 @@ export default class CacheRequest extends Request {
 
   set url(urlString) {
     super.url = urlString;
-    const pathname = global.decodeURIComponent(url.parse(urlString).pathname).replace(/^\//g, '');
-    const urlParts = pathname.split('/');
+    let pathname = url.parse(urlString).pathname;
+
+    try {
+      pathname = global.decodeURIComponent(url.parse(urlString).pathname);
+    } catch (error) {
+      // Just catch the URI Malformed error
+    }
+
+    const urlParts = pathname.replace(/^\//g, '').split('/');
     // "pathname" has the following form "/namespace/appKey/collection/id"
     this.appKey = urlParts[1];
     this.collection = urlParts[2];

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -386,7 +386,7 @@ describe('SyncStore', function() {
 
     it('should call update() for an entity that contains an _id with special characters', function() {
       const store = new SyncStore(collection);
-      const specialSymbols = ['.' /* , '$', '~', '>', '<', '!', '@', '%' */ ];
+      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@' /*, '%' */];
       const savePromises = specialSymbols.map(symbol => {
         const id = `${randomString()}${symbol}${randomString()}`;
         return store.save({ _id: id })
@@ -395,11 +395,8 @@ describe('SyncStore', function() {
             expect(resp._id).toEqual(id);
           });
       });
-      
-      Promise.all(savePromises)
-        .catch(() => {
-          throw new Error('This test should fail.');
-        });
+
+      return Promise.all(savePromises);
     });
 
     it('should call create() when an array of entities is provided', function() {

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -386,7 +386,7 @@ describe('SyncStore', function() {
 
     it('should call update() for an entity that contains an _id with special characters', function() {
       const store = new SyncStore(collection);
-      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@', '%'];
+      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@'];
       const savePromises = specialSymbols.map(symbol => {
         const id = `${randomString()}${symbol}${randomString()}`;
         return store.save({ _id: id })

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -384,6 +384,24 @@ describe('SyncStore', function() {
       expect(spy).toHaveBeenCalled();
     });
 
+    it('should call update() for an entity that contains an _id with special characters', function() {
+      const store = new SyncStore(collection);
+      const specialSymbols = ['.' /* , '$', '~', '>', '<', '!', '@', '%' */ ];
+      const savePromises = specialSymbols.map(symbol => {
+        const id = `${randomString()}${symbol}${randomString()}`;
+        return store.save({ _id: id })
+          .then(resp => {
+            expect(resp).toExist();
+            expect(resp._id).toEqual(id);
+          });
+      });
+      
+      Promise.all(savePromises)
+        .catch(() => {
+          throw new Error('This test should fail.');
+        });
+    });
+
     it('should call create() when an array of entities is provided', function() {
       const store = new SyncStore(collection);
       const spy = expect.spyOn(store, 'create');

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -386,7 +386,7 @@ describe('SyncStore', function() {
 
     it('should call update() for an entity that contains an _id with special characters', function() {
       const store = new SyncStore(collection);
-      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@' /*, '%' */];
+      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@', '%'];
       const savePromises = specialSymbols.map(symbol => {
         const id = `${randomString()}${symbol}${randomString()}`;
         return store.save({ _id: id })


### PR DESCRIPTION
#### Description
This PR should fix MLIBZ-1919 and MLIBZ-1677.

#### Changes
Parse path segments for cache requests manually and remove library from dependencies. Add library for joining URLs and ensure paths don't start with multiple slashes, because that broke the assertions in the tests due to discrepancies between mocked URLs and requested URLs.

#### Tests
Added new test for "." in _id. Old tests pass.

@thomasconner Other special characters seem to fail. If you want to release today, you might take a look. Otherwise I will work it out on Monday.
