### PR TITLE
MLIBZ-1899: Fix Error Inheritance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "append-query": "2.0.1",
     "core-js": "2.4.1",
-    "es6-error": "4.0.2",
     "es6-promise": "4.1.0",
     "fast-memory-cache": "2.0.4",
     "hellojs": "1.14.1",

--- a/src/errors/src/activeUser.js
+++ b/src/errors/src/activeUser.js
@@ -1,7 +1,14 @@
 import BaseError from './base';
 
-export default class ActiveUserError extends BaseError {
-  constructor(message = 'An active user already exists.', debug, code, kinveyRequestId) {
-    super('ActiveUserError', message, debug, code, kinveyRequestId);
-  }
+function ActiveUserError(message, debug, code, kinveyRequestId) {
+  this.name = 'ActiveUserError';
+  this.message = message || 'An active user already exists.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+ActiveUserError.prototype = Object.create(BaseError.prototype);
+ActiveUserError.prototype.constructor = ActiveUserError;
+export default ActiveUserError;
+

--- a/src/errors/src/apiVersionNotAvailable.js
+++ b/src/errors/src/apiVersionNotAvailable.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class APIVersionNotAvailableError extends BaseError {
-  constructor(message = 'This API version is not available for your app.'
-    + ' Please retry your request with a supported API version.', debug, code, kinveyRequestId) {
-    super('APIVersionNotAvailableError', message, debug, code, kinveyRequestId);
-  }
+function APIVersionNotAvailableError(message, debug, code, kinveyRequestId) {
+  this.name = 'APIVersionNotAvailableError';
+  this.message = message || 'This API version is not available for your app.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+APIVersionNotAvailableError.prototype = Object.create(BaseError.prototype);
+APIVersionNotAvailableError.prototype.constructor = APIVersionNotAvailableError;
+export default APIVersionNotAvailableError;

--- a/src/errors/src/apiVersionNotImplemented.js
+++ b/src/errors/src/apiVersionNotImplemented.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class APIVersionNotImplementedError extends BaseError {
-  constructor(message = 'This API version is not implemented.'
-    + ' Please retry your request with a supported API version.', debug, code, kinveyRequestId) {
-    super('APIVersionNotImplementedError', message, debug, code, kinveyRequestId);
-  }
+function APIVersionNotImplementedError(message, debug, code, kinveyRequestId) {
+  this.name = 'APIVersionNotImplementedError';
+  this.message = message || 'This API version is not implemented.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+APIVersionNotImplementedError.prototype = Object.create(BaseError.prototype);
+APIVersionNotImplementedError.prototype.constructor = APIVersionNotImplementedError;
+export default APIVersionNotImplementedError;

--- a/src/errors/src/appProblem.js
+++ b/src/errors/src/appProblem.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class AppProblemError extends BaseError {
-  constructor(message = 'There is a problem with this app backend that prevents execution of this operation.'
-    + ' Please contact support@kinvey.com for assistance.', debug, code, kinveyRequestId) {
-    super('AppProblemError', message, debug, code, kinveyRequestId);
-  }
+function AppProblemError(message, debug, code, kinveyRequestId) {
+  this.name = 'AppProblemError';
+  this.message = message || 'There is a problem with this app backend that prevents execution of this operation. Please contact support@kinvey.com for assistance.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+AppProblemError.prototype = Object.create(BaseError.prototype);
+AppProblemError.prototype.constructor = AppProblemError;
+export default AppProblemError;

--- a/src/errors/src/badRequest.js
+++ b/src/errors/src/badRequest.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class BadRequestError extends BaseError {
-  constructor(message = 'Unable to understand request.', debug, code, kinveyRequestId) {
-    super('BadRequestError', message, debug, code, kinveyRequestId);
-  }
+function BadRequestError(message, debug, code, kinveyRequestId) {
+  this.name = 'BadRequestError';
+  this.message = message || 'Unable to understand request.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+BadRequestError.prototype = Object.create(BaseError.prototype);
+BadRequestError.prototype.constructor = BadRequestError;
+export default BadRequestError;

--- a/src/errors/src/base.js
+++ b/src/errors/src/base.js
@@ -1,13 +1,11 @@
-import ExtendableError from 'es6-error';
-
-export default class BaseError extends ExtendableError {
-  constructor(name, message = 'An error occurred.', debug = '', code = -1, kinveyRequestId) {
-    super();
-    this.name = name || this.constructor.name;
-    this.message = message;
-    this.debug = debug;
-    this.code = code;
-    this.kinveyRequestId = kinveyRequestId;
-    this.stack = (new Error(message)).stack;
-  }
+function BaseError(message, debug, code, kinveyRequestId) {
+  this.name = 'BaseError';
+  this.message = message || 'An error occurred.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+BaseError.prototype = Object.create(Error.prototype);
+BaseError.prototype.constructor = BaseError;
+export default BaseError;

--- a/src/errors/src/bl.js
+++ b/src/errors/src/bl.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class BLError extends BaseError {
-  constructor(message = 'The Business Logic script did not complete.'
-    + ' See debug message for details.', debug, code, kinveyRequestId) {
-    super('BLError', message, debug, code, kinveyRequestId);
-  }
+function BLError(message, debug, code, kinveyRequestId) {
+  this.name = 'BLError';
+  this.message = message || 'The Business Logic script did not complete.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+BLError.prototype = Object.create(BaseError.prototype);
+BLError.prototype.constructor = BLError;
+export default BLError;

--- a/src/errors/src/corsDisabled.js
+++ b/src/errors/src/corsDisabled.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class CORSDisabledError extends BaseError {
-  constructor(message = 'Cross Origin Support is disabled for this application.', debug, code, kinveyRequestId) {
-    super('CORSDisabledError', message, debug, code, kinveyRequestId);
-  }
+function CORSDisabledError(message, debug, code, kinveyRequestId) {
+  this.name = 'CORSDisabledError';
+  this.message = message || 'Cross Origin Support is disabled for this application.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+CORSDisabledError.prototype = Object.create(BaseError.prototype);
+CORSDisabledError.prototype.constructor = CORSDisabledError;
+export default CORSDisabledError;

--- a/src/errors/src/duplicateEndUsers.js
+++ b/src/errors/src/duplicateEndUsers.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class DuplicateEndUsersError extends BaseError {
-  constructor(message = 'More than one user registered with this username for this application.'
-    + ' Please contact support@kinvey.com for assistance.', debug, code, kinveyRequestId) {
-    super('DuplicateEndUsersError', message, debug, code, kinveyRequestId);
-  }
+function DuplicateEndUsersError(message, debug, code, kinveyRequestId) {
+  this.name = 'DuplicateEndUsersError';
+  this.message = message || 'More than one user registered with this username for this application.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+DuplicateEndUsersError.prototype = Object.create(BaseError.prototype);
+DuplicateEndUsersError.prototype.constructor = DuplicateEndUsersError;
+export default DuplicateEndUsersError;

--- a/src/errors/src/featureUnavailable.js
+++ b/src/errors/src/featureUnavailable.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class FeatureUnavailableError extends BaseError {
-  constructor(message = 'Requested functionality is unavailable in this API version.', debug, code, kinveyRequestId) {
-    super('FeatureUnavailableError', message, debug, code, kinveyRequestId);
-  }
+function FeatureUnavailableError(message, debug, code, kinveyRequestId) {
+  this.name = 'FeatureUnavailableError';
+  this.message = message || 'Requested functionality is unavailable in this API version.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+FeatureUnavailableError.prototype = Object.create(BaseError.prototype);
+FeatureUnavailableError.prototype.constructor = FeatureUnavailableError;
+export default FeatureUnavailableError;

--- a/src/errors/src/incompleteRequestBody.js
+++ b/src/errors/src/incompleteRequestBody.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class IncompleteRequestBodyError extends BaseError {
-  constructor(message = 'The request body is either missing or incomplete.', debug, code, kinveyRequestId) {
-    super('IncompleteRequestBodyError', message, debug, code, kinveyRequestId);
-  }
+function IncompleteRequestBodyError(message, debug, code, kinveyRequestId) {
+  this.name = 'IncompleteRequestBodyError';
+  this.message = message || 'The request body is either missing or incomplete.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+IncompleteRequestBodyError.prototype = Object.create(BaseError.prototype);
+IncompleteRequestBodyError.prototype.constructor = IncompleteRequestBodyError;
+export default IncompleteRequestBodyError;

--- a/src/errors/src/indirectCollectionAccessDisallowed.js
+++ b/src/errors/src/indirectCollectionAccessDisallowed.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class IndirectCollectionAccessDisallowedError extends BaseError {
-  constructor(message = 'Please use the appropriate API to access this'
-    + ' collection for this app backend.', debug, code, kinveyRequestId) {
-    super('IndirectCollectionAccessDisallowedError', message, debug, code, kinveyRequestId);
-  }
+function IndirectCollectionAccessDisallowedError(message, debug, code, kinveyRequestId) {
+  this.name = 'IndirectCollectionAccessDisallowedError';
+  this.message = message || 'Please use the appropriate API to access this collection for this app backend.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+IndirectCollectionAccessDisallowedError.prototype = Object.create(BaseError.prototype);
+IndirectCollectionAccessDisallowedError.prototype.constructor = IndirectCollectionAccessDisallowedError;
+export default IndirectCollectionAccessDisallowedError;

--- a/src/errors/src/insufficientCredentials.js
+++ b/src/errors/src/insufficientCredentials.js
@@ -1,10 +1,13 @@
 import BaseError from './base';
 
-export default class InsufficientCredentialsError extends BaseError {
-  constructor(message = 'The credentials used to authenticate this' +
-    ' request are not authorized to run' +
-    ' this operation. Please retry your' +
-    ' request with appropriate credentials.', debug, code, kinveyRequestId) {
-    super('InsufficientCredentialsError', message, debug, code, kinveyRequestId);
-  }
+function InsufficientCredentialsError(message, debug, code, kinveyRequestId) {
+  this.name = 'InsufficientCredentialsError';
+  this.message = message || 'The credentials used to authenticate this request are not authorized to run this operation. Please retry your request with appropriate credentials.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+InsufficientCredentialsError.prototype = Object.create(BaseError.prototype);
+InsufficientCredentialsError.prototype.constructor = InsufficientCredentialsError;
+export default InsufficientCredentialsError;

--- a/src/errors/src/invalidCredentials.js
+++ b/src/errors/src/invalidCredentials.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class InvalidCredentialsError extends BaseError {
-  constructor(message = 'Invalid credentials.'
-    + ' Please retry your request with correct credentials.', debug, code, kinveyRequestId) {
-    super('InvalidCredentialsError', message, debug, code, kinveyRequestId);
-  }
+function InvalidCredentialsError(message, debug, code, kinveyRequestId) {
+  this.name = 'InvalidCredentialsError';
+  this.message = message || 'Invalid credentials. Please retry your request with correct credentials.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+InvalidCredentialsError.prototype = Object.create(BaseError.prototype);
+InvalidCredentialsError.prototype.constructor = InvalidCredentialsError;
+export default InvalidCredentialsError;

--- a/src/errors/src/invalidIdentifier.js
+++ b/src/errors/src/invalidIdentifier.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class InvalidIdentifierError extends BaseError {
-  constructor(message = 'One of more identifier names in the'
-    + ' request has an invalid format.', debug, code, kinveyRequestId) {
-    super('InvalidIdentifierError', message, debug, code, kinveyRequestId);
-  }
+function InvalidIdentifierError(message, debug, code, kinveyRequestId) {
+  this.name = 'InvalidIdentifierError';
+  this.message = message || 'One of more identifier names in the request has an invalid format.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+InvalidIdentifierError.prototype = Object.create(BaseError.prototype);
+InvalidIdentifierError.prototype.constructor = InvalidIdentifierError;
+export default InvalidIdentifierError;

--- a/src/errors/src/invalidQuerySyntax.js
+++ b/src/errors/src/invalidQuerySyntax.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class InvalidQuerySyntaxError extends BaseError {
-  constructor(message = 'The query string in the request has an invalid syntax.', debug, code, kinveyRequestId) {
-    super('InvalidQuerySyntaxError', message, debug, code, kinveyRequestId);
-  }
+function InvalidQuerySyntaxError(message, debug, code, kinveyRequestId) {
+  this.name = 'InvalidQuerySyntaxError';
+  this.message = message || 'The query string in the request has an invalid syntax.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+InvalidQuerySyntaxError.prototype = Object.create(BaseError.prototype);
+InvalidQuerySyntaxError.prototype.constructor = InvalidQuerySyntaxError;
+export default InvalidQuerySyntaxError;

--- a/src/errors/src/jsonParse.js
+++ b/src/errors/src/jsonParse.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class JSONParseError extends BaseError {
-  constructor(message = 'Unable to parse the JSON in the request.', debug, code, kinveyRequestId) {
-    super('JSONParseError', message, debug, code, kinveyRequestId);
-  }
+function JSONParseError(message, debug, code, kinveyRequestId) {
+  this.name = 'JSONParseError';
+  this.message = message || 'Unable to parse the JSON in the request.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+JSONParseError.prototype = Object.create(BaseError.prototype);
+JSONParseError.prototype.constructor = JSONParseError;
+export default JSONParseError;

--- a/src/errors/src/kinvey.js
+++ b/src/errors/src/kinvey.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class KinveyError extends BaseError {
-  constructor(message, debug, code, kinveyRequestId) {
-    super('KinveyError', message, debug, code, kinveyRequestId);
-  }
+function KinveyError(message, debug, code, kinveyRequestId) {
+  this.name = 'KinveyError';
+  this.message = message || 'An error occurred.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+KinveyError.prototype = Object.create(BaseError.prototype);
+KinveyError.prototype.constructor = KinveyError;
+export default KinveyError;

--- a/src/errors/src/kinveyInternalErrorRetry.js
+++ b/src/errors/src/kinveyInternalErrorRetry.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class KinveyInternalErrorRetry extends BaseError {
-  constructor(message = 'The Kinvey server encountered an unexpected error.'
-    + ' Please retry your request.', debug, code, kinveyRequestId) {
-    super('KinveyInternalErrorRetry', message, debug, code, kinveyRequestId);
-  }
+function KinveyInternalErrorRetry(message, debug, code, kinveyRequestId) {
+  this.name = 'KinveyInternalErrorRetry';
+  this.message = message || 'The Kinvey server encountered an unexpected error. Please retry your request.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+KinveyInternalErrorRetry.prototype = Object.create(BaseError.prototype);
+KinveyInternalErrorRetry.prototype.constructor = KinveyInternalErrorRetry;
+export default KinveyInternalErrorRetry;

--- a/src/errors/src/kinveyInternalErrorStop.js
+++ b/src/errors/src/kinveyInternalErrorStop.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class KinveyInternalErrorStop extends BaseError {
-  constructor(message = 'The Kinvey server encountered an unexpected error.'
-    + ' Please contact support@kinvey.com for assistance.', debug, code, kinveyRequestId) {
-    super('KinveyInternalErrorStop', message, debug, code, kinveyRequestId);
-  }
+function KinveyInternalErrorStop(message, debug, code, kinveyRequestId) {
+  this.name = 'KinveyInternalErrorStop';
+  this.message = message || 'The Kinvey server encountered an unexpected error. Please contact support@kinvey.com for assistance.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+KinveyInternalErrorStop.prototype = Object.create(BaseError.prototype);
+KinveyInternalErrorStop.prototype.constructor = KinveyInternalErrorStop;
+export default KinveyInternalErrorStop;

--- a/src/errors/src/missingQuery.js
+++ b/src/errors/src/missingQuery.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class MissingQueryError extends BaseError {
-  constructor(message = 'The request is missing a query string.', debug, code, kinveyRequestId) {
-    super('MissingQueryError', message, debug, code, kinveyRequestId);
-  }
+function MissingQueryError(message, debug, code, kinveyRequestId) {
+  this.name = 'MissingQueryError';
+  this.message = message || 'The request is missing a query string.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+MissingQueryError.prototype = Object.create(BaseError.prototype);
+MissingQueryError.prototype.constructor = MissingQueryError;
+export default MissingQueryError;

--- a/src/errors/src/missingRequestHeader.js
+++ b/src/errors/src/missingRequestHeader.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class MissingRequestHeaderError extends BaseError {
-  constructor(message = 'The request is missing a required header.', debug, code, kinveyRequestId) {
-    super('MissingRequestHeaderError', message, debug, code, kinveyRequestId);
-  }
+function MissingRequestHeaderError(message, debug, code, kinveyRequestId) {
+  this.name = 'MissingRequestHeaderError';
+  this.message = message || 'The request is missing a required header.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+MissingRequestHeaderError.prototype = Object.create(BaseError.prototype);
+MissingRequestHeaderError.prototype.constructor = MissingRequestHeaderError;
+export default MissingRequestHeaderError;

--- a/src/errors/src/missingRequestParameter.js
+++ b/src/errors/src/missingRequestParameter.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class MissingRequestParameterError extends BaseError {
-  constructor(message = 'A required parameter is missing from the request.', debug, code, kinveyRequestId) {
-    super('MissingRequestParameterError', message, debug, code, kinveyRequestId);
-  }
+function MissingRequestParameterError(message, debug, code, kinveyRequestId) {
+  this.name = 'MissingRequestParameterError';
+  this.message = message || 'A required parameter is missing from the request.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+MissingRequestParameterError.prototype = Object.create(BaseError.prototype);
+MissingRequestParameterError.prototype.constructor = MissingRequestParameterError;
+export default MissingRequestParameterError;

--- a/src/errors/src/mobileIdentityConnect.js
+++ b/src/errors/src/mobileIdentityConnect.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class MobileIdentityConnectError extends BaseError {
-  constructor(message = 'An error has occurred with Mobile Identity Connect.', debug, code) {
-    super('MobileIdentityConnectError', message, debug, code);
-  }
+function MobileIdentityConnectError(message, debug, code, kinveyRequestId) {
+  this.name = 'MobileIdentityConnectError';
+  this.message = message || 'An error has occurred with Mobile Identity Connect.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+MobileIdentityConnectError.prototype = Object.create(BaseError.prototype);
+MobileIdentityConnectError.prototype.constructor = MobileIdentityConnectError;
+export default MobileIdentityConnectError;

--- a/src/errors/src/networkConnection.js
+++ b/src/errors/src/networkConnection.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class NetworkConnectionError extends BaseError {
-  constructor(message = 'There was an error connecting to the network.', debug, code, kinveyRequestId) {
-    super('NetworkConnectionError', message, debug, code, kinveyRequestId);
-  }
+function NetworkConnectionError(message, debug, code, kinveyRequestId) {
+  this.name = 'NetworkConnectionError';
+  this.message = message || 'There was an error connecting to the network.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+NetworkConnectionError.prototype = Object.create(BaseError.prototype);
+NetworkConnectionError.prototype.constructor = NetworkConnectionError;
+export default NetworkConnectionError;

--- a/src/errors/src/noActiveUser.js
+++ b/src/errors/src/noActiveUser.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class NoActiveUserError extends BaseError {
-  constructor(message = 'There is not an active user.', debug, code, kinveyRequestId) {
-    super('NoActiveUserError', message, debug, code, kinveyRequestId);
-  }
+function NoActiveUserError(message, debug, code, kinveyRequestId) {
+  this.name = 'NoActiveUserError';
+  this.message = message || 'There is not an active user.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+NoActiveUserError.prototype = Object.create(BaseError.prototype);
+NoActiveUserError.prototype.constructor = NoActiveUserError;
+export default NoActiveUserError;

--- a/src/errors/src/noResponse.js
+++ b/src/errors/src/noResponse.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class NoResponseError extends BaseError {
-  constructor(message = 'No response was provided.', debug, code, kinveyRequestId) {
-    super('NoResponseError', message, debug, code, kinveyRequestId);
-  }
+function NoResponseError(message, debug, code, kinveyRequestId) {
+  this.name = 'NoResponseError';
+  this.message = message || 'No response was provided.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+NoResponseError.prototype = Object.create(BaseError.prototype);
+NoResponseError.prototype.constructor = NoResponseError;
+export default NoResponseError;

--- a/src/errors/src/notFound.js
+++ b/src/errors/src/notFound.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class NotFoundError extends BaseError {
-  constructor(message = 'The entity was not found.', debug, code = 404, kinveyRequestId) {
-    super('NotFoundError', message, debug, code, kinveyRequestId);
-  }
+function NotFoundError(message, debug, code, kinveyRequestId) {
+  this.name = 'NotFoundError';
+  this.message = message || 'The entity was not found.';
+  this.debug = debug || undefined;
+  this.code = code || 404;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+NotFoundError.prototype = Object.create(BaseError.prototype);
+NotFoundError.prototype.constructor = NotFoundError;
+export default NotFoundError;

--- a/src/errors/src/parameterValueOutOfRange.js
+++ b/src/errors/src/parameterValueOutOfRange.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class ParameterValueOutOfRangeError extends BaseError {
-  constructor(message = 'The value specified for one of the'
-    + ' request parameters is out of range.', debug, code, kinveyRequestId) {
-    super('ParameterValueOutOfRangeError', message, debug, code, kinveyRequestId);
-  }
+function ParameterValueOutOfRangeError(message, debug, code, kinveyRequestId) {
+  this.name = 'ParameterValueOutOfRangeError';
+  this.message = message || 'The value specified for one of the request parameters is out of range.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+ParameterValueOutOfRangeError.prototype = Object.create(BaseError.prototype);
+ParameterValueOutOfRangeError.prototype.constructor = ParameterValueOutOfRangeError;
+export default ParameterValueOutOfRangeError;

--- a/src/errors/src/popup.js
+++ b/src/errors/src/popup.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class PopupError extends BaseError {
-  constructor(message = 'Unable to open a popup on this platform.', debug, code, kinveyRequestId) {
-    super('PopupError', message, debug, code, kinveyRequestId);
-  }
+function PopupError(message, debug, code, kinveyRequestId) {
+  this.name = 'PopupError';
+  this.message = message || 'Unable to open a popup on this platform.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+PopupError.prototype = Object.create(BaseError.prototype);
+PopupError.prototype.constructor = PopupError;
+export default PopupError;

--- a/src/errors/src/query.js
+++ b/src/errors/src/query.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class QueryError extends BaseError {
-  constructor(message = 'An error occurred with the query.', debug, code, kinveyRequestId) {
-    super('QueryError', message, debug, code, kinveyRequestId);
-  }
+function QueryError(message, debug, code, kinveyRequestId) {
+  this.name = 'QueryError';
+  this.message = message || 'An error occurred with the query.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+QueryError.prototype = Object.create(BaseError.prototype);
+QueryError.prototype.constructor = QueryError;
+export default QueryError;

--- a/src/errors/src/server.js
+++ b/src/errors/src/server.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class ServerError extends BaseError {
-  constructor(message = 'An error occurred on the server.', debug, code = 500, kinveyRequestId) {
-    super('ServerError', message, debug, code, kinveyRequestId);
-  }
+function ServerError(message, debug, code, kinveyRequestId) {
+  this.name = 'ServerError';
+  this.message = message || 'An error occurred on the server.';
+  this.debug = debug || undefined;
+  this.code = code || 500;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+ServerError.prototype = Object.create(BaseError.prototype);
+ServerError.prototype.constructor = ServerError;
+export default ServerError;

--- a/src/errors/src/staleRequest.js
+++ b/src/errors/src/staleRequest.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class StaleRequestError extends BaseError {
-  constructor(message = 'The time window for this request has expired.', debug, code, kinveyRequestId) {
-    super('StaleRequestError', message, debug, code, kinveyRequestId);
-  }
+function StaleRequestError(message, debug, code, kinveyRequestId) {
+  this.name = 'StaleRequestError';
+  this.message = message || 'The time window for this request has expired.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+StaleRequestError.prototype = Object.create(BaseError.prototype);
+StaleRequestError.prototype.constructor = StaleRequestError;
+export default StaleRequestError;

--- a/src/errors/src/sync.js
+++ b/src/errors/src/sync.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class SyncError extends BaseError {
-  constructor(message = 'An error occurred during sync.', debug, code, kinveyRequestId) {
-    super('SyncError', message, debug, code, kinveyRequestId);
-  }
+function SyncError(message, debug, code, kinveyRequestId) {
+  this.name = 'SyncError';
+  this.message = message || 'An error occurred during sync.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+SyncError.prototype = Object.create(BaseError.prototype);
+SyncError.prototype.constructor = SyncError;
+export default SyncError;

--- a/src/errors/src/timeout.js
+++ b/src/errors/src/timeout.js
@@ -1,7 +1,13 @@
 import BaseError from './base';
 
-export default class TimeoutError extends BaseError {
-  constructor(message = 'The request timed out.', debug, code) {
-    super('TimeoutError', message, debug, code);
-  }
+function TimeoutError(message, debug, code, kinveyRequestId) {
+  this.name = 'TimeoutError';
+  this.message = message || 'The request timed out.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+TimeoutError.prototype = Object.create(BaseError.prototype);
+TimeoutError.prototype.constructor = TimeoutError;
+export default TimeoutError;

--- a/src/errors/src/userAlreadyExists.js
+++ b/src/errors/src/userAlreadyExists.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class UserAlreadyExistsError extends BaseError {
-  constructor(message = 'This username is already taken.'
-    + ' Please retry your request with a different username.', debug, code, kinveyRequestId) {
-    super('UserAlreadyExistsError', message, debug, code, kinveyRequestId);
-  }
+function UserAlreadyExistsError(message, debug, code, kinveyRequestId) {
+  this.name = 'UserAlreadyExistsError';
+  this.message = message || 'This username is already taken. Please retry your request with a different username.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+UserAlreadyExistsError.prototype = Object.create(BaseError.prototype);
+UserAlreadyExistsError.prototype.constructor = UserAlreadyExistsError;
+export default UserAlreadyExistsError;

--- a/src/errors/src/writesToCollectionDisallowed.js
+++ b/src/errors/src/writesToCollectionDisallowed.js
@@ -1,8 +1,13 @@
 import BaseError from './base';
 
-export default class WritesToCollectionDisallowedError extends BaseError {
-  constructor(message = 'This collection is configured to disallow any'
-    + ' modifications to an existing entity or creation of new entities.', debug, code, kinveyRequestId) {
-    super('WritesToCollectionDisallowedError', message, debug, code, kinveyRequestId);
-  }
+function WritesToCollectionDisallowedError(message, debug, code, kinveyRequestId) {
+  this.name = 'WritesToCollectionDisallowedError';
+  this.message = message || 'This collection is configured to disallow any modifications to an existing entity or creation of new entities.';
+  this.debug = debug || undefined;
+  this.code = code || undefined;
+  this.kinveyRequestId = kinveyRequestId || undefined;
+  this.stack = (new Error()).stack;
 }
+WritesToCollectionDisallowedError.prototype = Object.create(BaseError.prototype);
+WritesToCollectionDisallowedError.prototype.constructor = WritesToCollectionDisallowedError;
+export default WritesToCollectionDisallowedError;

--- a/test/errors/activeUser.test.js
+++ b/test/errors/activeUser.test.js
@@ -39,9 +39,9 @@ describe('ActiveUserError', () => {
   });
 
   describe('debug', () => {
-    it('should return the default debug message \'\'', () => {
+    it('should return the default debug message undefined', () => {
       const error = new ActiveUserError();
-      expect(error.debug).toEqual('');
+      expect(error.debug).toEqual(undefined);
     });
 
     it('should return the custom debug message \'Please logout with Kinvey.User.logout.\'', () => {
@@ -51,9 +51,9 @@ describe('ActiveUserError', () => {
   });
 
   describe('code', () => {
-    it('should return the default code -1', () => {
+    it('should return the default code undefined', () => {
       const error = new ActiveUserError();
-      expect(error.code).toEqual(-1);
+      expect(error.code).toEqual(undefined);
     });
 
     it('should return the custom code 309', () => {

--- a/test/request/network.test.js
+++ b/test/request/network.test.js
@@ -163,7 +163,7 @@ describe('KinveyRequest', () => {
             expect(error).toBeA(InvalidCredentialsError);
             expect(error.name).toEqual('InvalidCredentialsError');
             expect(error.message).toEqual('Invalid credentials. Please retry your request with correct credentials.');
-            expect(error.debug).toEqual('');
+            expect(error.debug).toEqual(undefined);
             expect(error.code).toEqual(401);
           });
       });
@@ -206,7 +206,7 @@ describe('KinveyRequest', () => {
                 expect(error).toBeA(InvalidCredentialsError);
                 expect(error.name).toEqual('InvalidCredentialsError');
                 expect(error.message).toEqual('Invalid credentials. Please retry your request with correct credentials.');
-                expect(error.debug).toEqual('');
+                expect(error.debug).toEqual(undefined);
                 expect(error.code).toEqual(401);
               });
           });


### PR DESCRIPTION
#### Description
This PR fixes error inheritances and removes the use of `es6-error`.

#### Changes
- Updated all errors to use the new inheritance model recommended on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error.
