### PR TITLE
Sdk on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postversion": "git push && git push --tags",
     "test": "mocha --compilers js:babel-core/register -r babel-polyfill -s 100 --recursive test/index test",
     "test:watch": "mocha -w --compilers js:babel-core/register -r babel-polyfill -s 100 --recursive test/index test",
-    "transpile": "BABEL_ENV=production babel --no-comments --out-dir dist src"
+    "transpile": "babel --no-comments --out-dir dist src"
   },
   "dependencies": {
     "append-query": "2.0.1",

--- a/src/request/src/cache.js
+++ b/src/request/src/cache.js
@@ -2,8 +2,6 @@ import Promise from 'es6-promise';
 import Queue from 'promise-queue';
 import url from 'url';
 import cloneDeep from 'lodash/cloneDeep';
-import identity from 'lodash/identity';
-import filter from 'lodash/filter';
 
 import Client from 'src/client';
 import { KinveyError } from 'src/errors';
@@ -70,9 +68,9 @@ export default class CacheRequest extends Request {
 
   set url(urlString) {
     super.url = urlString;
-    let pathname = global.decodeURIComponent(url.parse(urlString).pathname);
-    const urlParts = pathname.replace(/^\//g, '').split('/');
-    // "pathname" has the following form "/namespace/appKey/collection/id"
+    const pathname = global.decodeURIComponent(url.parse(urlString).pathname);
+    const urlParts = pathname.replace(/^\//, '').split('/');
+    // "pathname" has the following form: "/namespace/appKey/collection/id"
     this.appKey = urlParts[1];
     this.collection = urlParts[2];
     this.entityId = urlParts[3];

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -386,17 +386,8 @@ describe('SyncStore', function() {
 
     it('should call update() for an entity that contains an _id with special characters', function() {
       const store = new SyncStore(collection);
-      const specialSymbols = ['.', '$', '~', '>', '<', '!', '@'];
-      const savePromises = specialSymbols.map(symbol => {
-        const id = `${randomString()}${symbol}${randomString()}`;
-        return store.save({ _id: id })
-          .then(resp => {
-            expect(resp).toExist();
-            expect(resp._id).toEqual(id);
-          });
-      });
-
-      return Promise.all(savePromises);
+      const id = '.$~<>!@+_#';
+      return store.save({ _id: id });
     });
 
     it('should call create() when an array of entities is provided', function() {

--- a/test/datastore/syncstore.test.js
+++ b/test/datastore/syncstore.test.js
@@ -387,7 +387,10 @@ describe('SyncStore', function() {
     it('should call update() for an entity that contains an _id with special characters', function() {
       const store = new SyncStore(collection);
       const id = '.$~<>!@+_#';
-      return store.save({ _id: id });
+      return store.save({ _id: id })
+        .then((resp) => {
+          expect(resp._id).toEqual(id);
+        });
     });
 
     it('should call create() when an array of entities is provided', function() {


### PR DESCRIPTION
#### Description
This is related to MLIBZ-1958. Setting environment variables has different syntax on Windows so I removed the setting of BABEL_ENV variable from the build command since it is in the .env file anyways. Babel doesn't seem to have any settings depending on its environment though, so this seems redundant.

Also altered the test for special symbols in the _id field slightly, to only create one item with all special symbols we agreed upon with Tejas.

#### Changes
No changes to the SDK itself, only to the build command and one test, as described above.
