### PR TITLE
MLIBZ-1835: Add micId to client_id used for MIC

### DIFF
--- a/src/identity/src/mic.js
+++ b/src/identity/src/mic.js
@@ -48,7 +48,11 @@ export class MobileIdentityConnect extends Identity {
   }
 
   login(redirectUri, authorizationGrant = AuthorizationGrant.AuthorizationCodeLoginPage, options = {}) {
-    const clientId = this.client.appKey;
+    let clientId = this.client.appKey;
+
+    if (isString(options.micId)) {
+      clientId = `${clientId}:${options.micId}`;
+    }
 
     const promise = Promise.resolve()
       .then(() => {


### PR DESCRIPTION
#### Description
Allows a user to provide optionally a `micId` that will be included with the `client_id` when attempting to login or refresh a token with MIC.

#### Changes
- Set `client_id` to `appKey:micId` if a `micId` is provided

#### Tests
- Added 2 tests. The first test checks that MIC ignores any invalid `micId`. The second test checks that the `client_id` is formatted correctly to include a `micId`. 