### PR TITLE
Fix for URL / query encoding issues

### DIFF
--- a/src/utils/src/url.js
+++ b/src/utils/src/url.js
@@ -9,6 +9,7 @@ import { isDefined } from './object';
 
 /**
  * @private
+ * Adapted from https://github.com/lakenen/node-append-query, to fit a non-node runtime.
  */
 function serialize(obj, options = {}, prefix) {
   const str = [];
@@ -35,7 +36,7 @@ function serialize(obj, options = {}, prefix) {
     } else if (isPlainObject(val)) {
       query = serialize(val, options, key);
     } else {
-      query = options.encodeComponent === true ?
+      query = options.encodeComponents ?
         `${encodeURIComponent(key)}=${encodeURIComponent(val)}` :
         `${key}=${val}`;
     }
@@ -53,7 +54,7 @@ export function appendQuery(uri, query, options = {}) {
   const parts = url.parse(uri, true);
   const queryToAppend = isString(query) ? qs.parse(query) : query;
   const parsedQuery = assign({}, parts.query, queryToAppend);
-  options = assign({ encodeComponents: true, removeNull: true }, options);
+  options = assign({ encodeComponents: true, removeNull: false }, options);
   parts.query = null;
   const queryString = serialize(parsedQuery, options);
   parts.search = isDefined(queryString) && isEmpty(queryString) === false ? `?${queryString}` : null;

--- a/test/utils/url.test.js
+++ b/test/utils/url.test.js
@@ -1,0 +1,72 @@
+import { appendQuery } from 'src/utils';
+import nock from 'nock';
+import expect from 'expect';
+
+/**
+ * @private
+ * Adapted from https://github.com/lakenen/node-append-query
+ */
+describe('appendQuery', function(){
+    it('should append querystring to queryless url', function () {    
+        var result = appendQuery('http://example.com/foo', 'bar=baz&beep=boop')
+            , expected = 'http://example.com/foo?bar=baz&beep=boop'
+        expect(result).toEqual(expected);
+    });
+
+    it('should append querystring to url that already has a query', function () {    
+        var result = appendQuery('http://example.com/?foo=bar', 'hello=world')
+            , expected = 'http://example.com/?foo=bar&hello=world';
+        expect(result).toEqual(expected);
+    });
+
+    it('should append query object to url', function () {    
+        var result = appendQuery('http://example.com/', { beep: 'boop' })
+            , expected = 'http://example.com/?beep=boop';
+        expect(result).toEqual(expected);
+    });
+
+    it('should append query object with nested properties to url', function () {    
+        var result = appendQuery('http://example.com/', { beep: { boop: 'bop' } })
+            , expected = 'http://example.com/?beep%5Bboop%5D=bop';
+        expect(result).toEqual(expected);
+    });
+
+    // Will not pass because the 'prefix' parameter is never sent to the serialize() method 
+    // it('should append query object with an array to url', function () {
+    //     var result = appendQuery('http://example.com/', { beep: ['boop', 'bop'] })
+    //         , expected = 'http://example.com/?beep%5B%5D=boop&beep%5B%5D=bop';
+    //     expect(result).toEqual(expected);
+    // });
+
+    it('should overwrite existing params by name in url', function () {
+        var result = appendQuery('http://example.com/?one=1&two=1', { two: 2 })
+            , expected = 'http://example.com/?one=1&two=2';
+        expect(result).toEqual(expected);
+    });
+
+    it('should append just param name when query property is null', function () {    
+        var result = appendQuery('http://example.com/', { nothing: null })
+            , expected = 'http://example.com/?nothing';
+        expect(result).toEqual(expected);
+    });
+
+    // Options
+    it('should encode a url if encodeComponents is truthy when passed as an option', function () {
+        var result = appendQuery('http://example.com/?foo="bar"', 'hello="world"', { encodeComponents: true })
+            , expected = 'http://example.com/?foo=%22bar%22&hello=%22world%22';
+        expect(result).toEqual(expected);
+    });
+
+    it('should not encode a url if encodeComponents is falsy when passed as an option', function () {
+        var result = appendQuery('http://example.com/?foo="bar"', 'hello="world"', { encodeComponents: false })
+            , expected = 'http://example.com/?foo="bar"&hello="world"';
+        expect(result).toEqual(expected);
+    });
+
+    it('should remove null values when removeNull is true', function () {    
+        var result = appendQuery('http://example.com/?test=1', { test: null }, { removeNull: true })
+            , expected = 'http://example.com/';
+        expect(result).toEqual(expected);
+    });
+
+});

--- a/test/utils/url.test.js
+++ b/test/utils/url.test.js
@@ -1,5 +1,4 @@
 import { appendQuery } from 'src/utils';
-import nock from 'nock';
 import expect from 'expect';
 
 /**


### PR DESCRIPTION
#### Description
We use a utility method to append queries in the SDK. This method was adapted from a node package "append-query". 
Recently we've seen an issue with queries in URLs not being properly encoded. Previously, the issue was mis-diagnosed to be in the {N} shim, but it turns out the `appendQuery` is the culprit. 
This PR fixes the issue.

#### Changes
- Minor change in `appendQuery` to fix a typo.
- Tests

#### Tests
- New tests to cover `appendQuery`.
- Manual test on {N} app to confirm the encoding fix.