### PR TITLE
Fix Kinvey.intialize() to resolve with an instance of Kinvey.User or null

### DIFF
--- a/src/kinvey.js
+++ b/src/kinvey.js
@@ -114,7 +114,7 @@ class Kinvey {
    */
   static initialize(config) {
     const client = Kinvey.init(config);
-    return Promise.resolve(client.getActiveUser());
+    return Promise.resolve(User.getActiveUser(client));
   }
 
   /**


### PR DESCRIPTION
#### Description
`Kinvey.initialize()` will resolve with an instance of a `Kinvey.User` or `null`. 

#### Changes
- Use the `User` class to resolve with the current active user or `null` for `Kinvey.initialize()`.