### PR TITLE
Live service improvements

### DIFF
--- a/src/kinvey.js
+++ b/src/kinvey.js
@@ -46,7 +46,7 @@ import DataStore, { DataStoreType, FileStore, SyncOperation } from './datastore'
 import { Acl, Metadata, User } from './entity';
 import { AuthorizationGrant } from './identity';
 import { AuthType, CacheRack, NetworkRack, Rack, RequestMethod, KinveyRequest } from './request';
-import { LiveServiceFacade, Stream } from './live';
+import { LiveServiceFacade } from './live';
 
 /**
  * The Kinvey class is used as the entry point for the Kinvey JavaScript SDK.

--- a/src/live/collection/live-collection-manager.js
+++ b/src/live/collection/live-collection-manager.js
@@ -13,7 +13,6 @@ export class LiveCollectionManager {
   _client;
 
   /**
-   * @param {LiveService} liveService
    * @param {Client} client
    */
   constructor(client) {

--- a/src/live/live-service-facade.js
+++ b/src/live/live-service-facade.js
@@ -25,13 +25,6 @@ function offConnectionStatusUpdates(func) {
 }
 
 /**
- * Unsubscribes from all channels and channel groups
- */
-function unsubscribeFromAll() {
-  _getLiveService().unsubscribeFromAll();
-}
-
-/**
  * Checks whether live service is ready to subscribe or publish messages
  */
 function isInitialized() {
@@ -42,6 +35,5 @@ export const LiveServiceFacade = {
   Stream,
   onConnectionStatusUpdates,
   offConnectionStatusUpdates,
-  unsubscribeFromAll,
   isInitialized
 };

--- a/src/live/live-service.js
+++ b/src/live/live-service.js
@@ -156,7 +156,7 @@ class LiveService {
    * Unsubscribes from all events in PubNub client and in listener
    */
   uninitialize() {
-    this.unsubscribeFromAll();
+    this._unsubscribeFromAll();
     this._pubnubClient = null;
     this._pubnubListener = null;
   }
@@ -233,14 +233,6 @@ class LiveService {
   }
 
   /**
-   * Unsubscribes from all channels and channel groups, as well as PubNubListener events
-   */
-  unsubscribeFromAll() {
-    this._pubnubClient.unsubscribeAll();
-    this._pubnubListener.removeAllListeners();
-  }
-
-  /**
    * @param {string} userId
    * @returns {Promise}
    */
@@ -256,6 +248,15 @@ class LiveService {
         this._registeredUser = null;
         return resp;
       });
+  }
+
+  /**
+   * Unsubscribes from all channels and channel groups, as well as PubNubListener events
+   * @private
+   */
+  _unsubscribeFromAll() {
+    this._pubnubClient.unsubscribeAll();
+    this._pubnubListener.removeAllListeners();
   }
 
   /**

--- a/src/live/user-to-user/stream-acl.js
+++ b/src/live/user-to-user/stream-acl.js
@@ -50,6 +50,7 @@ export class StreamACL {
 
   /**
    * @param  {(User|User[]|string|string[])} publishers
+   * @returns {this}
    */
   addPublishers(publishers) {
     this._addToAcl(this.publishers, publishers);
@@ -58,6 +59,7 @@ export class StreamACL {
 
   /**
    * @param  {(User|User[]|string|string[])} subscribers
+   * @returns {this}
    */
   addSubscribers(subscribers) {
     this._addToAcl(this.subscribers, subscribers);
@@ -66,6 +68,7 @@ export class StreamACL {
 
   /**
    * @param  {(string|string[]|{_id: string})} groups
+   * @returns {this}
    */
   addPublisherGroups(groups) {
     this._addToAcl(this.publisherGroups, groups);
@@ -74,11 +77,13 @@ export class StreamACL {
 
   /**
    * @param  {(string|string[]|{_id: string})} groups
+   * @returns {this}
    */
   addSubscriberGroups(groups) {
     this._addToAcl(this.publisherGroups, groups);
     return this;
   }
+
   /**
    * Indicates whether the current object has any user IDs,
    * in any of its fields

--- a/test/live/collection/live-collection-manager.test.js
+++ b/test/live/collection/live-collection-manager.test.js
@@ -4,8 +4,7 @@ import { getLiveCollectionManager, LiveCollectionManager } from '../../../src/li
 
 import * as nockHelper from '../';
 import { mockRequiresIn } from '../../mocks';
-
-const invalidOrMissingCheckRegexp = new RegExp('(invalid)|(missing)', 'i');
+import { invalidOrMissingCheckRegexp } from '../utilities';
 
 describe('LiveCollectionManager', () => {
   /** @type {LiveCollectionManager} */

--- a/test/live/live-service-facade.test.js
+++ b/test/live/live-service-facade.test.js
@@ -13,7 +13,6 @@ const liveServiceMock = {
   unregisterUser: () => { },
   onConnectionStatusUpdates: () => { },
   offConnectionStatusUpdates: () => { },
-  unsubscribeFromAll: () => { },
   isInitialized: () => { }
 };
 
@@ -37,7 +36,6 @@ describe('LiveServiceFacade', () => {
       'Stream',
       'onConnectionStatusUpdates',
       'offConnectionStatusUpdates',
-      'unsubscribeFromAll',
       'isInitialized'
     ];
     expect(LiveServiceFacade).toContainKeys(expectedMethods);
@@ -59,16 +57,6 @@ describe('LiveServiceFacade', () => {
       const handler = () => { };
       LiveServiceFacade.offConnectionStatusUpdates(handler);
       expect(spy).toHaveBeenCalledWith(handler);
-    });
-  });
-
-  describe('unsubscribeFromAll', () => {
-    it('should call LiveService\'s unsubscribeFromAll() method', () => {
-      const spy = expect.spyOn(liveServiceMock, 'unsubscribeFromAll');
-      LiveServiceFacade.unsubscribeFromAll();
-      expect(spy).toHaveBeenCalled();
-      expect(spy.calls.length).toBe(1);
-      expect(spy.calls[0].arguments.length).toBe(0);
     });
   });
 

--- a/test/live/live-service.test.js
+++ b/test/live/live-service.test.js
@@ -9,9 +9,11 @@ import { PubNubListener, getLiveService } from '../../src/live';
 import { PubNubClientMock, PubNubListenerMock } from '../mocks';
 
 const pathToLiveService = '../../src/live/live-service';
-const notInitializedCheckRegexp = new RegExp('not.*initialized', 'i');
-const invalidOrMissingCheckRegexp = new RegExp('(invalid)|(missing)', 'i');
-const alreadyInitializedCheckRegexp = new RegExp('already initialized', 'i');
+import {
+  notInitializedCheckRegexp,
+  invalidOrMissingCheckRegexp,
+  alreadyInitializedCheckRegexp
+} from './utilities';
 
 describe('LiveService', () => {
   let client;

--- a/test/live/live-service.test.js
+++ b/test/live/live-service.test.js
@@ -374,13 +374,6 @@ describe('LiveService', () => {
         })
           .toThrow(notInitializedCheckRegexp);
       });
-
-      it('should fail for unsubscribeFromAll()', () => {
-        expect(() => {
-          liveService.unsubscribeFromAll();
-        })
-          .toThrow(notInitializedCheckRegexp);
-      });
     });
 
     describe('when LiveService is initialized', () => {
@@ -410,22 +403,6 @@ describe('LiveService', () => {
           expect(spy.calls.length).toBe(2);
           expect(spy).toHaveBeenCalledWith(channelName);
           expect(spy).toHaveBeenCalledWith(`${PubNubListener.statusPrefix}${channelName}`);
-        });
-      });
-
-      describe('unsubscribeFromAll()', () => {
-        it('should call unsubscribeAll() of PubNub client', () => {
-          const clientSpy = expect.spyOn(pubnubClient, 'unsubscribeAll');
-
-          liveService.unsubscribeFromAll();
-          expect(clientSpy).toHaveBeenCalledWith();
-        });
-
-        it('should call removeAllListeners() of PubNubListener', () => {
-          const listenerSpy = expect.spyOn(pubnubListener, 'removeAllListeners');
-
-          liveService.unsubscribeFromAll();
-          expect(listenerSpy).toHaveBeenCalledWith();
         });
       });
     });

--- a/test/live/nock-helper.js
+++ b/test/live/nock-helper.js
@@ -58,6 +58,12 @@ export function mockSetStreamACLRequest(streamName, substreamId, aclObj) {
     });
 }
 
+export function mockGetStreamACLRequest(streamName, substreamId, response) {
+  return _baseNockCall()
+    .get(_buildSubstreamACLUrl(streamName, substreamId))
+    .reply(200, response);
+}
+
 export function mockCollectionSubscribeRequest(collectionName) {
   return _baseNockCall()
     .post(_buildCollectionSubscriptionUrl(collectionName, '_subscribe'), { deviceId: _client.deviceId })

--- a/test/live/user-to-user/stream.test.js
+++ b/test/live/user-to-user/stream.test.js
@@ -5,6 +5,7 @@ import { Stream } from '../../../src/live';
 
 import { randomString } from '../../../src/utils';
 import * as nockHelper from '../nock-helper';
+import { invalidOrMissingCheckRegexp } from '../utilities';
 
 // TODO: add more tests
 
@@ -31,6 +32,39 @@ describe('Stream', () => {
         .then((resp) => {
           scope.done();
           expect(resp).toEqual(responseMock);
+        });
+    });
+  });
+
+  describe('getACL', () => {
+    it('should throw an error if supplied substream id is invalid', (done) => {
+      stream.getACL('')
+        .then(() => done(new Error('getACL succeeded with invalid id')))
+        .catch((err) => {
+          expect(err).toExist();
+          expect(err.message).toMatch(invalidOrMissingCheckRegexp);
+          done();
+        });
+    });
+
+    it('should throw an error if no substream is provided', (done) => {
+      stream.getACL()
+        .then(() => done(new Error('getACL succeeded with invalid id')))
+        .catch((err) => {
+          expect(err).toExist();
+          expect(err.message).toMatch(invalidOrMissingCheckRegexp);
+          done();
+        });
+    });
+
+    it('should make a request to the provided substream id', () => {
+      const mockResponse = { anyObject: true };
+      const scope = nockHelper.mockGetStreamACLRequest(streamName, substreamId, mockResponse);
+
+      return stream.getACL(substreamId)
+        .then((aclObj) => {
+          scope.done();
+          expect(aclObj).toEqual(mockResponse);
         });
     });
   });
@@ -66,7 +100,7 @@ describe('Stream', () => {
         .addPublishers('some id')
         .addSubscribers('some other id');
 
-      const scope = nockHelper.mockSetStreamACLRequest(streamName, substreamId, acl.toPlainObject())
+      const scope = nockHelper.mockSetStreamACLRequest(streamName, substreamId, acl.toPlainObject());
       return stream.setACL(substreamId, acl)
         .then((resp) => {
           scope.done();

--- a/test/live/utilities.js
+++ b/test/live/utilities.js
@@ -1,0 +1,3 @@
+export const invalidOrMissingCheckRegexp = new RegExp('(invalid)|(missing)', 'i');
+export const notInitializedCheckRegexp = new RegExp('not.*initialized', 'i');
+export const alreadyInitializedCheckRegexp = new RegExp('already initialized', 'i');


### PR DESCRIPTION
#### Description
Small improvements and refactoring for live service related code. If we wish to keep the `unsubscribeFromAll()` method public, we should make it more user friendly, since it now puts the `LiveService` class in an inconvenient state.

#### Changes
Add `getACL()` method for `Stream` class.  Small refactoring and jsdoc adjustments. Remove potentially problematic method `unsubscribeFromAll()`.

#### Tests
Add tests for the new `getACL()` method. Remove tests for the (now private) `_unsubscribeFromAll()` method of `LiveService` class. All remaining tests pass.
