### PR TITLE
StreamACL class fixes and improvements

### DIFF
--- a/src/live/user-to-user/stream-acl.js
+++ b/src/live/user-to-user/stream-acl.js
@@ -81,7 +81,43 @@ export class StreamACL {
    * @returns {this}
    */
   addSubscriberGroups(groups) {
-    this._addToAcl(this.publisherGroups, groups);
+    this._addToAcl(this.subscriberGroups, groups);
+    return this;
+  }
+
+  /**
+   * @param  {(User|User[]|string|string[])} publishers
+   * @returns {this}
+   */
+  removePublishers(publishers) {
+    this._removeFromAcl(this.publishers, publishers);
+    return this;
+  }
+
+  /**
+   * @param  {(User|User[]|string|string[])} subscribers
+   * @returns {this}
+   */
+  removeSubscribers(subscribers) {
+    this._removeFromAcl(this.subscribers, subscribers);
+    return this;
+  }
+
+  /**
+   * @param  {(string|string[]|{_id: string})} groups
+   * @returns {this}
+   */
+  removePublisherGroups(groups) {
+    this._removeFromAcl(this.publisherGroups, groups);
+    return this;
+  }
+
+  /**
+   * @param  {(string|string[]|{_id: string})} groups
+   * @returns {this}
+   */
+  removeSubscriberGroups(groups) {
+    this._removeFromAcl(this.subscriberGroups, groups);
     return this;
   }
 
@@ -148,6 +184,7 @@ export class StreamACL {
       }
     }
   }
+
   /**
    * Ensures that the specified array contains only nonempty strings
    * so that it can be assigned to a {@link StreamACL} property
@@ -162,6 +199,7 @@ export class StreamACL {
     }
     return arr;
   }
+
   /**
    * @private
    * @param {string[]} arr
@@ -169,7 +207,7 @@ export class StreamACL {
    */
   _isValidIdArray(arr) {
     return isArray(arr) && every(arr, (o) => {
-      const id = o._id ? o._id : o;
+      const id = this._getAsId(o);
       return isNonemptyString(id);
     });
   }
@@ -187,9 +225,36 @@ export class StreamACL {
       throw new KinveyError(invalidValueMsg);
     }
 
-    usersArr.forEach((subscriber) => {
-      const id = subscriber._id ? subscriber._id : subscriber;
+    usersArr.forEach((u) => {
+      const id = this._getAsId(u);
       arr.push(id);
     });
+  }
+
+  /**
+   * @private
+   * @param {string[]} arr The appropriate array to add users to -
+   *    subscribers (or groups of them) or publishers (or groups of them)
+   * @param {(User|User[]|string|string[])} users
+   */
+  _removeFromAcl(arr, users) {
+    const usersArr = isArray(users) ? users : [users];
+
+    usersArr.forEach((u) => {
+      const id = this._getAsId(u);
+      const index = arr.indexOf(id);
+      if (index >= 0) {
+        arr.splice(index, 1);
+      }
+    });
+  }
+
+  /**
+   * @private
+   * @param {Object} object Object which contains an "_id" property or is itself an id
+   * @returns {string} The value of the "_id" property of the object, or the object itself, if it doesn't have such a property
+   */
+  _getAsId(o) {
+    return (o && o._id) ? o._id : o;
   }
 }

--- a/src/live/user-to-user/stream-acl.js
+++ b/src/live/user-to-user/stream-acl.js
@@ -3,6 +3,7 @@ import isString from 'lodash/isString';
 import every from 'lodash/every';
 
 import { KinveyError } from '../../errors';
+import { isNonemptyString } from '../../utils';
 
 const invalidValueMsg = 'Invalid ACL object value';
 
@@ -155,7 +156,7 @@ export class StreamACL {
    * @returns {string[]} The same array, if it is valid
    */
   _ensureValidIdArray(arr) {
-    const isValid = this._isNonemptyStringArray(arr);
+    const isValid = this._isValidIdArray(arr);
     if (!isValid) {
       throw new KinveyError(invalidValueMsg);
     }
@@ -166,8 +167,11 @@ export class StreamACL {
    * @param {string[]} arr
    * @returns {boolean}
    */
-  _isNonemptyStringArray(arr) {
-    return isArray(arr) && every(arr, id => isString(id) && id !== '');
+  _isValidIdArray(arr) {
+    return isArray(arr) && every(arr, (o) => {
+      const id = o._id ? o._id : o;
+      return isNonemptyString(id);
+    });
   }
 
   /**
@@ -178,7 +182,7 @@ export class StreamACL {
    */
   _addToAcl(arr, users) {
     const usersArr = isArray(users) ? users : [users];
-    const isValid = this._isNonemptyStringArray(usersArr);
+    const isValid = this._isValidIdArray(usersArr);
     if (!isValid) {
       throw new KinveyError(invalidValueMsg);
     }

--- a/src/live/user-to-user/stream-acl.js
+++ b/src/live/user-to-user/stream-acl.js
@@ -1,5 +1,4 @@
 import isArray from 'lodash/isArray';
-import isString from 'lodash/isString';
 import every from 'lodash/every';
 
 import { KinveyError } from '../../errors';


### PR DESCRIPTION
Handles MLIBZ-2100 and MLIBZ-2101.
Fix `StreamACL` validation check to allow passing User objects to the class's methods. Add methods for removing subscribers, publishers and groups of them.

#### Description
`StreamACL` was meant to accept `User` objects but the validation added later on didn't take that into account. Remove methods were missing because there used to be no ability to get the current ACL, so you only ever needed to build new ACL objects.

#### Changes
Amended the validation check when. Add methods for removing subscribers, publishers and groups of them.

#### Tests
All tests pass. None were added, even though we should, at some point.