### PR TITLE
MLIBZ-2225: datastore.findById() should throw a NotFoundError if the id argument is not defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2630,6 +2630,15 @@
         "mime-types": "2.1.17"
       }
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "formidable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
@@ -4588,6 +4597,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4784,6 +4799,12 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -4807,6 +4828,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz",
       "integrity": "sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI="
+    },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -5171,6 +5198,27 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
     },
     "nock": {
       "version": "9.1.3",
@@ -5643,6 +5691,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "1.1.0",
@@ -6352,6 +6417,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "schema-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
@@ -6425,6 +6496,32 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
+      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "4.5.0",
+        "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -6780,6 +6877,12 @@
           "dev": true
         }
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-extensions": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nock": "~9.1.3",
     "proxyquire": "~1.8.0",
     "rimraf": "~2.6.2",
+    "sinon": "^4.1.3",
     "tns-core-modules": "3.0.1",
     "tns-platform-declarations": "3.0.1",
     "ts-loader": "~3.2.0",

--- a/src/html5/storage/websql.js
+++ b/src/html5/storage/websql.js
@@ -1,12 +1,12 @@
 import Promise from 'es6-promise';
-import { KinveyError } from '../../core/errors';
+import { KinveyError, NotFoundError } from '../../core/errors';
 import { isDefined } from '../../core/utils';
 
 const masterCollectionName = 'sqlite_master';
 const size = 2 * 1024 * 1024; // Database size in bytes
 let isSupported;
 
-class WebSQL {
+export class WebSQL {
   constructor(name = 'kinvey') {
     if (isDefined(name) === false) {
       throw new KinveyError('A name is required to use the WebSQL adapter.', name);

--- a/src/html5/storage/websql.js
+++ b/src/html5/storage/websql.js
@@ -107,7 +107,14 @@ class WebSQL {
     const sql = 'SELECT value FROM #{collection} WHERE key = ?';
     return this.openTransaction(collection, sql, [id])
       .then(response => response.result)
-      .then((entities) => entities[0]);
+      .then((entities) => {
+        if (entities.length === 0) {
+          throw new NotFoundError(`An entity with _id = ${id} was not found in the ${collection}` +
+            ` collection on the ${this.name} WebSQL database.`);
+        }
+
+        return entities[0];
+      });
   }
 
   save(collection, entities) {

--- a/src/html5/storage/websql.spec.js
+++ b/src/html5/storage/websql.spec.js
@@ -1,0 +1,20 @@
+import Promise from 'es6-promise';
+import { expect, use } from 'chai';
+import { stub } from 'sinon';
+import { WebSQL } from './websql';
+import { NotFoundError } from '../../core/errors';
+
+use(require('chai-as-promised'));
+
+describe('WebSQL', () => {
+  describe('findById()', () => {
+    it('should throw a NotFoundError for an id that does not exist', () => {
+      const websql = new WebSQL('test');
+      const openTransactionStub = stub(websql, 'openTransaction').callsFake(() => {
+        return Promise.resolve({ result: [] });
+      });
+      const promise = websql.findById('iddoesnotexist');
+      return expect(promise).to.be.rejectedWith(NotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
#### Description
Add validation check to `datastore.findById()` for `id` argument. Throw a `NotFoundError` if the `id` argument is not defined.

#### Tests
Updated unit tests for each datastore type to check if a `NotFoundError` is thrown when the `id` argument is not defined.