### PR TITLE
MLIBZ-2150 Fix setting active user in NativeScript SDK

### DIFF
--- a/src/nativescript/client.ts
+++ b/src/nativescript/client.ts
@@ -24,18 +24,8 @@ class ActiveUserStorage {
       throw new KinveyError('The key argument must be a string.');
     }
 
-    let valueToSave = value;
-
-    if (value !== null && value !== undefined && typeof value === 'object') {
-      valueToSave = JSON.stringify(value);
-    }
-
-    if (value !== null && value !== undefined && typeof value !== 'string') {
-      valueToSave = String(value);
-    }
-
     if (isDefined(value)) {
-      storage.set(key, valueToSave);
+      storage.set(key, value);
     } else {
       this.remove(key);
     }


### PR DESCRIPTION
#### Description
This should fix MLIBZ-2150.

#### Changes
Remove redundant modifications of the value to be saved before saving it, when setting the active user. They are present in the set() methods of SecureStorage for both Android and iOS. I misunderstood them last time and that caused a different bug.
