### PR TITLE
MLIBZ-2157: Add filter for a not equal query properly

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -665,7 +665,7 @@ export class Query {
    */
   addFilter(field, condition, values) {
     if (isDefined(condition)
-        && (isDefined(values) || condition === '$ne')) {
+      && (isDefined(values) || arguments.length === 3)) {
       if (!isPlainObject(this.filter[field])) {
         this.filter[field] = {};
       }

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -664,7 +664,8 @@ export class Query {
    * @returns {Query} The query.
    */
   addFilter(field, condition, values) {
-    if (isDefined(condition) && isDefined(values)) {
+    if (isDefined(condition)
+        && (isDefined(values) || condition === '$ne')) {
       if (!isPlainObject(this.filter[field])) {
         this.filter[field] = {};
       }

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -355,6 +355,15 @@ describe('Query', () => {
       const query = new Query().notEqualTo(randomString(), randomString());
       expect(query).to.be.an.instanceof(Query);
     });
+
+    it('should filter out fields not equal to null', () => {
+      const entity1 = { customProperty: null };
+      const entity2 = { customProperty: randomString() };
+      const query = new Query().notEqualTo('customProperty', null);
+      const result = query.process([entity1, entity2]);
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.deep.equal(entity2);
+    });
   });
 
   describe('notContainedIn()', () => {


### PR DESCRIPTION
#### Changes
I added a condition to the `if` statement in the `addFilter()` function for a query to handle the special use case for `$ne`.

#### Tests
I added a unit tests that verifies that a `$ne` query filters data correctly.