### PR TITLE
MLIBZ-2154: Remove fields when processing query after sorting data

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -765,21 +765,6 @@ export class Query {
 
     Log.debug('Data length after applying query filter', json.filter, data.length);
 
-    // Remove fields
-    if (Array.isArray(json.fields) && json.fields.length > 0) {
-      Log.debug('Removing fields from data', json.fields);
-      data = data.map((item) => {
-        const keys = Object.keys(item);
-        keys.forEach((key) => {
-          if (json.fields.indexOf(key) === -1) {
-            delete item[key];
-          }
-        });
-
-        return item;
-      });
-    }
-
     /* eslint-disable no-restricted-syntax, no-prototype-builtins  */
     // Sorting.
     if (isDefined(json.sort)) {
@@ -806,6 +791,21 @@ export class Query {
       });
     }
     /* eslint-enable no-restricted-syntax, no-prototype-builtins */
+
+    // Remove fields
+    if (Array.isArray(json.fields) && json.fields.length > 0) {
+      Log.debug('Removing fields from data', json.fields);
+      data = data.map((item) => {
+        const keys = Object.keys(item);
+        keys.forEach((key) => {
+          if (json.fields.indexOf(key) === -1) {
+            delete item[key];
+          }
+        });
+
+        return item;
+      });
+    }
 
     // Limit and skip.
     if (isNumber(json.skip)) {

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -915,6 +915,16 @@ describe('Query', () => {
       expect(query.toPlainObject().sort[field1]).to.equal(1);
       expect(query.toPlainObject().sort[field2]).to.equal(-1);
     });
+
+    it('should sort the data in ascending order', () => {
+      const entity1 = { _id: 1, customProperty: randomString() };
+      const entity2 = { _id: 2, customProperty: randomString() };
+      const query = new Query().ascending('_id');
+      query.fields = ['customProperty'];
+      const result = query.process([entity2, entity1]);
+      expect(result[0].customProperty).to.equal(entity1.customProperty);
+      expect(result[1].customProperty).to.equal(entity2.customProperty);
+    });
   });
 
   describe('descending()', () => {
@@ -943,6 +953,16 @@ describe('Query', () => {
       query.ascending(field2);
       expect(query.toPlainObject().sort[field1]).to.equal(-1);
       expect(query.toPlainObject().sort[field2]).to.equal(1);
+    });
+
+    it('should sort the data in descending order', () => {
+      const entity1 = { _id: 1, customProperty: randomString() };
+      const entity2 = { _id: 2, customProperty: randomString() };
+      const query = new Query().descending('_id');
+      query.fields = ['customProperty'];
+      const result = query.process([entity1, entity2]);
+      expect(result[0].customProperty).to.equal(entity2.customProperty);
+      expect(result[1].customProperty).to.equal(entity1.customProperty);
     });
   });
 


### PR DESCRIPTION
#### Changes
A query will now remove fields after applying the sorting when processing data.

#### Test
I added 2 new unit tests. The first test checks that a query sorts the data in ascending order correctly when the sorting is applied to a field that is removed. The second test checks that a query sorts the data in descending order correctly when the sorting is applied to a field that is removed. 