### PR TITLE
QA-135 Fix linting errors in integration tests.

### DIFF
--- a/packages/kinvey-html5-sdk/runner-config.js
+++ b/packages/kinvey-html5-sdk/runner-config.js
@@ -2,62 +2,59 @@ const path = require('path');
 const walk = require('klaw-sync');
 
 const {
-    Runner,
-    tasks: {
-        logServer,
-        copy,
-        copyTestRunner,
-        copyTestLibs,
-        runCommand,
-        remove,
-        processTemplateFile
-    }
+  Runner,
+  tasks: {
+    logServer,
+    runCommand,
+    remove,
+    processTemplateFile
+  }
 } = require('kinvey-universal-runner');
 
 const serveTests = require('./test/tasks/serveTests');
 const webRunTests = require('./test/tasks/webRunTests');
 const rootMonoRepoPath = path.join(__dirname, '../../');
-const distPath =  path.join(__dirname, 'dist');
+const distPath = path.join(__dirname, 'dist');
 
 let logServerPort;
 let staticPort;
 
-const jsFilesFilter = item => path.extname(item.path) === '.js'
+const jsFilesFilter = item => path.extname(item.path) === '.js';
 const shimSpecificTests = walk(path.join(__dirname, 'test', 'tests'), {
-    filter: jsFilesFilter,
-    nodir: true
+  filter: jsFilesFilter,
+  nodir: true
 });
 const commonTests = walk(path.join(rootMonoRepoPath, 'test', 'integration'), {
-    filter: jsFilesFilter,
-    nodir: true
+  filter: jsFilesFilter,
+  nodir: true
 });
 
 const runner = new Runner({
-    pipeline: [
-        logServer(),
-        remove(distPath),
-        runCommand({
-            command: 'npm',
-            args: ['run', 'build'],
-            cwd: rootMonoRepoPath
-        }),
-        processTemplateFile(
-            path.join(__dirname, 'test', 'index.template.hbs'),
-            () => ({
-                tests: shimSpecificTests.concat(commonTests).map(
-                    f =>
-                        `./${path.relative(
-                            path.join(__dirname, 'test'),
-                            f.path
-                        )}`
-                ),
-                logServerPort
-            }),
-            path.join(rootMonoRepoPath, 'packages', 'kinvey-html5-sdk', 'test', 'index.html')
+  pipeline: [
+    logServer(),
+    remove(distPath),
+    runCommand({
+      command: 'npm',
+      args: ['run', 'build'],
+      cwd: rootMonoRepoPath
+    }),
+    processTemplateFile(
+      path.join(__dirname, 'test', 'index.template.hbs'),
+      () => ({
+        tests: shimSpecificTests.concat(commonTests).map(
+          f =>
+            `./${path.relative(
+              path.join(__dirname, 'test'),
+              f.path
+            )}`
         ),
-        serveTests(rootMonoRepoPath),
-        webRunTests(() => staticPort)
-    ]
+        logServerPort
+      }),
+      path.join(rootMonoRepoPath, 'packages', 'kinvey-html5-sdk', 'test', 'index.html')
+    ),
+    serveTests(rootMonoRepoPath),
+    webRunTests(() => staticPort)
+  ]
 });
 
 runner.on('log.start', port => (logServerPort = port));

--- a/packages/kinvey-html5-sdk/test/config.js
+++ b/packages/kinvey-html5-sdk/test/config.js
@@ -1,5 +1,5 @@
 externalConfig = {
-    appKey: 'kid_H1fs4gFsZ',
-    appSecret: 'aa42a6d47d0049129c985bfb37821877',
-    collectionName: 'Books' 
+  appKey: 'kid_H1fs4gFsZ',
+  appSecret: 'aa42a6d47d0049129c985bfb37821877',
+  collectionName: 'Books'
 };

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "no-unused-expressions": "off",
+    "prefer-destructuring": "off",
+    "wrap-iife": "off"
+  },
+  "globals": {
+    "Kinvey": true,
+    "expect": true,
+    "utilities": true,
+    "runner": true,
+    "externalConfig": true,
+    "sinon": true,
+    "_": true,
+    "window": true,
+    "Constants": true
+  }
+}

--- a/test/integration/crud-entity/common-crud.test.js
+++ b/test/integration/crud-entity/common-crud.test.js
@@ -1,9 +1,8 @@
 function testFunc() {
-
   const dataStoreTypes = [Kinvey.DataStoreType.Network, Kinvey.DataStoreType.Sync, Kinvey.DataStoreType.Cache];
   const invalidQueryMessage = 'Invalid query. It must be an instance of the Query class.';
   const notFoundErrorName = 'NotFoundError';
-  const collectionName = externalConfig.collectionName;
+  const { collectionName } = externalConfig;
 
   dataStoreTypes.forEach((currentDataStoreType) => {
     describe(`CRUD Entity - ${currentDataStoreType}`, () => {
@@ -14,7 +13,7 @@ function testFunc() {
       let networkStore;
       let storeToTest;
       const dataStoreType = currentDataStoreType;
-      let createdUserIds = [];
+      const createdUserIds = [];
 
       const entity1 = utilities.getEntity(utilities.randomString());
       const entity2 = utilities.getEntity(utilities.randomString());
@@ -22,14 +21,12 @@ function testFunc() {
 
       before((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
-          .then(() => {
-            return Kinvey.User.signup()
-          })
+          .then(() => Kinvey.User.signup())
           .then((user) => {
             createdUserIds.push(user.data._id);
-            //store for setup
+            // store for setup
             networkStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Network);
-            //store to test
+            // store to test
             storeToTest = Kinvey.DataStore.collection(collectionName, dataStoreType);
             done();
           })
@@ -39,25 +36,21 @@ function testFunc() {
       after((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
           .then(() => done())
-          .catch(done)
+          .catch(done);
       });
       describe('find and count operations', () => {
-
         before((done) => {
           networkStore.save(entity1)
-            .then(() => {
-              return networkStore.save(entity2)
-            })
+            .then(() => networkStore.save(entity2))
             .then(() => {
               if (dataStoreType !== Kinvey.DataStoreType.Network) {
-                return storeToTest.pull()
+                return storeToTest.pull();
               }
+              return Promise.resolve();
             })
-            .then(() => {
-              return networkStore.save(entity3)
-            })
+            .then(() => networkStore.save(entity3))
             .then(() => done())
-            .catch(done)
+            .catch(done);
         });
 
         describe('count()', () => {
@@ -102,7 +95,7 @@ function testFunc() {
           });
         });
 
-        describe('find()', function () {
+        describe('find()', () => {
           it('should throw an error if the query argument is not an instance of the Query class', (done) => {
             storeToTest.find({})
               .subscribe(null, (error) => {
@@ -120,7 +113,7 @@ function testFunc() {
             storeToTest.find()
               .subscribe(onNextSpy, done, () => {
                 try {
-                  utilities.validateReadResult(dataStoreType, onNextSpy, [entity1, entity2], [entity1, entity2, entity3], true)
+                  utilities.validateReadResult(dataStoreType, onNextSpy, [entity1, entity2], [entity1, entity2, entity3], true);
                   return utilities.retrieveEntity(collectionName, Kinvey.DataStoreType.Sync, entity3)
                     .then((result) => {
                       if (result) {
@@ -128,10 +121,12 @@ function testFunc() {
                       }
                       expect(result).to.deep.equal(dataStoreType === Kinvey.DataStoreType.Cache ? entity3 : undefined);
                       done();
-                    }).catch(done);
+                    })
+                    .catch(done);
                 } catch (error) {
                   done(error);
                 }
+                return Promise.resolve();
               });
           });
 
@@ -142,7 +137,7 @@ function testFunc() {
             storeToTest.find(query)
               .subscribe(onNextSpy, done, () => {
                 try {
-                  utilities.validateReadResult(dataStoreType, onNextSpy, [entity2], [entity2])
+                  utilities.validateReadResult(dataStoreType, onNextSpy, [entity2], [entity2]);
                   done();
                 } catch (error) {
                   done(error);
@@ -159,7 +154,8 @@ function testFunc() {
               .catch((error) => {
                 expect(error.name).to.contain(notFoundErrorName);
                 done();
-              }).catch(done);
+              })
+              .catch(done);
           });
 
           it('should return undefined if an id is not provided', (done) => {
@@ -167,7 +163,8 @@ function testFunc() {
               .then((result) => {
                 expect(result).to.be.undefined;
                 done();
-              }).catch(done);
+              })
+              .catch(done);
           });
 
           it('should return the entity that matches the id argument', (done) => {
@@ -175,7 +172,7 @@ function testFunc() {
             storeToTest.findById(entity2._id)
               .subscribe(onNextSpy, done, () => {
                 try {
-                  utilities.validateReadResult(dataStoreType, onNextSpy, entity2, entity2)
+                  utilities.validateReadResult(dataStoreType, onNextSpy, entity2, entity2);
                   done();
                 } catch (error) {
                   done(error);
@@ -191,19 +188,17 @@ function testFunc() {
         let entities = [];
         const dataCount = 10;
         before((done) => {
-
-          for (let i = 0; i < dataCount; i++) {
+          for (let i = 0; i < dataCount; i += 1) {
             entities.push(utilities.getEntity());
           }
 
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => {
-              return utilities.saveEntities(collectionName, entities)
-            })
+            .then(() => utilities.saveEntities(collectionName, entities))
             .then((result) => {
               entities = result;
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should sort ascending and skip correctly', (done) => {
@@ -258,7 +253,7 @@ function testFunc() {
             });
         });
 
-        //skipped because of a bug for syncStore and different behaviour of fields for Sync and Network
+        // skipped because of a bug for syncStore and different behaviour of fields for Sync and Network
         it.skip('with fields should return only the specified fields', (done) => {
           const onNextSpy = sinon.spy();
           const query = new Kinvey.Query();
@@ -280,35 +275,33 @@ function testFunc() {
       describe('Querying', () => {
         let entities = [];
         const dataCount = 10;
-        const secondSortField = 'secondSortField'
+        const secondSortField = 'secondSortField';
         let onNextSpy;
         let query;
 
         before((done) => {
-
-          for (let i = 0; i < dataCount; i++) {
+          for (let i = 0; i < dataCount; i += 1) {
             entities.push(utilities.getEntity(null, `test_${i}`, i, [`test_${i % 5}`, `second_test_${i % 5}`, `third_test_${i % 5}`]));
           }
 
-          const textArray = ['aaa', 'aaB', 'aac']
-          for (let i = 0; i < dataCount; i++) {
+          const textArray = ['aaa', 'aaB', 'aac'];
+          for (let i = 0; i < dataCount; i += 1) {
             entities[i].secondSortField = textArray[i % 3];
           }
 
           // used to test exists and size operators and null values
           entities[dataCount - 1][textFieldName] = null;
-          delete entities[dataCount - 1][numberFieldName]
+          delete entities[dataCount - 1][numberFieldName];
           entities[dataCount - 1][arrayFieldName] = [];
           entities[dataCount - 2][arrayFieldName] = [{}, {}];
 
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => {
-              return utilities.saveEntities(collectionName, entities)
-            })
+            .then(() => utilities.saveEntities(collectionName, entities))
             .then((result) => {
               entities = _.sortBy(result, numberFieldName);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         beforeEach((done) => {
@@ -317,8 +310,7 @@ function testFunc() {
           done();
         });
 
-        describe('Comparison operators', function () {
-
+        describe('Comparison operators', () => {
           it('query.equalTo', (done) => {
             query.equalTo(textFieldName, entities[5][textFieldName]);
             const expectedEntities = [entities[5]];
@@ -349,7 +341,7 @@ function testFunc() {
 
           it('query.notEqualTo', (done) => {
             query.notEqualTo(textFieldName, entities[5][textFieldName]);
-            const expectedEntities = entities.filter(entity => entity != entities[5]);
+            const expectedEntities = entities.filter(entity => entity !== entities[5]);
             storeToTest.find(query)
               .subscribe(onNextSpy, done, () => {
                 try {
@@ -361,10 +353,10 @@ function testFunc() {
               });
           });
 
-          //should be added back for execution when MLIBZ-2157 is fixed
+          // should be added back for execution when MLIBZ-2157 is fixed
           it.skip('query.notEqualTo with null', (done) => {
             query.notEqualTo(textFieldName, null);
-            const expectedEntities = entities.filter(entity => entity[textFieldName] != null);
+            const expectedEntities = entities.filter(entity => entity[textFieldName] !== null);
             storeToTest.find(query)
               .subscribe(onNextSpy, done, () => {
                 try {
@@ -434,7 +426,7 @@ function testFunc() {
 
           it('query.exists', (done) => {
             query.exists(numberFieldName);
-            const expectedEntities = entities.filter(entity => entity != entities[dataCount - 1]);
+            const expectedEntities = entities.filter(entity => entity !== entities[dataCount - 1]);
             storeToTest.find(query)
               .subscribe(onNextSpy, done, () => {
                 try {
@@ -460,7 +452,7 @@ function testFunc() {
               });
           });
 
-          //TODO: Add more tests for regular expression
+          // TODO: Add more tests for regular expression
           it('query.matches - with RegExp literal', (done) => {
             query.matches(textFieldName, /^test_5/);
             const expectedEntities = [entities[5]];
@@ -506,9 +498,7 @@ function testFunc() {
         });
 
         describe('Array Operators', () => {
-
           describe('query.contains()', () => {
-
             it('with single value', (done) => {
               query.contains(textFieldName, entities[5][textFieldName]);
               const expectedEntities = [entities[5]];
@@ -582,7 +572,6 @@ function testFunc() {
           });
 
           describe('query.containsAll()', () => {
-
             it('with single value', (done) => {
               query.containsAll(textFieldName, entities[5][textFieldName]);
               const expectedEntities = [entities[5]];
@@ -613,7 +602,7 @@ function testFunc() {
 
             it('array field with an array of values', (done) => {
               const arrayFieldValue = entities[5][arrayFieldName];
-              const filteredArray = arrayFieldValue.filter(entity => entity != arrayFieldValue[2]);
+              const filteredArray = arrayFieldValue.filter(entity => entity !== arrayFieldValue[2]);
               query.containsAll(arrayFieldName, filteredArray);
               const expectedEntities = [entities[0], entities[5]];
               storeToTest.find(query)
@@ -644,10 +633,9 @@ function testFunc() {
           });
 
           describe('query.notContainedIn()', () => {
-
             it('with single value', (done) => {
               query.notContainedIn(textFieldName, entities[5][textFieldName]);
-              const expectedEntities = entities.filter(entity => entity != entities[5]);
+              const expectedEntities = entities.filter(entity => entity !== entities[5]);
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
@@ -661,7 +649,7 @@ function testFunc() {
 
             it('string property with an array of values', (done) => {
               query.notContainedIn(textFieldName, entities[0][arrayFieldName]);
-              const expectedEntities = entities.filter(entity => entity != entities[0]);
+              const expectedEntities = entities.filter(entity => entity !== entities[0]);
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
@@ -675,7 +663,7 @@ function testFunc() {
 
             it('array field with an array of values', (done) => {
               query.notContainedIn(arrayFieldName, entities[0][arrayFieldName]);
-              const expectedEntities = entities.filter(entity => entity != entities[0] && entity != entities[5]);
+              const expectedEntities = entities.filter(entity => entity !== entities[0] && entity !== entities[5]);
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
@@ -704,10 +692,9 @@ function testFunc() {
           });
 
           describe('query.size()', () => {
-
             it('should return the elements with an array field, having the submitted size', (done) => {
               query.size(arrayFieldName, 3);
-              const expectedEntities = entities.filter(entity => entity != entities[dataCount - 1] && entity != entities[dataCount - 2]);
+              const expectedEntities = entities.filter(entity => entity !== entities[dataCount - 1] && entity !== entities[dataCount - 2]);
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
@@ -751,13 +738,11 @@ function testFunc() {
         });
 
         describe('Modifiers', () => {
-
           let expectedAscendingCache;
           let expectedAscendingServer;
           let expectedDescending;
 
           describe('Sort', () => {
-
             before((done) => {
               expectedAscendingCache = _.sortBy(entities, numberFieldName);
               expectedAscendingServer = _.sortBy(entities, numberFieldName);
@@ -771,7 +756,7 @@ function testFunc() {
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
-                    //when MLIBZ-2156 is fixed, expectedAscendingCache should be replaced with expectedAscendingServer
+                    // when MLIBZ-2156 is fixed, expectedAscendingCache should be replaced with expectedAscendingServer
                     utilities.validateReadResult(dataStoreType, onNextSpy, expectedAscendingCache, expectedAscendingServer);
                     done();
                   } catch (error) {
@@ -797,8 +782,8 @@ function testFunc() {
               query.ascending(secondSortField);
               query.descending(textFieldName);
               query.notEqualTo('_id', entities[dataCount - 1]._id);
-              const sortedEntities = _.orderBy(entities, [secondSortField, numberFieldName], ['asc', 'desc'])
-              const expectedEntities = sortedEntities.filter(entity => entity != entities[dataCount - 1])
+              const sortedEntities = _.orderBy(entities, [secondSortField, numberFieldName], ['asc', 'desc']);
+              const expectedEntities = sortedEntities.filter(entity => entity !== entities[dataCount - 1]);
               storeToTest.find(query)
                 .subscribe(onNextSpy, done, () => {
                   try {
@@ -842,7 +827,7 @@ function testFunc() {
 
             it('should skip and then limit correctly', (done) => {
               query.limit = 2;
-              query.skip = 3
+              query.skip = 3;
               query.descending(numberFieldName);
               const expectedEntities = expectedDescending.slice(3, 5);
               storeToTest.find(query)
@@ -860,12 +845,9 @@ function testFunc() {
       });
 
       describe('save()', () => {
-
         before((done) => {
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => {
-              return utilities.saveEntities(collectionName, [entity1, entity2])
-            })
+            .then(() => utilities.saveEntities(collectionName, [entity1, entity2]))
             .then(() => done())
             .catch(done);
         });
@@ -873,10 +855,10 @@ function testFunc() {
         beforeEach((done) => {
           if (dataStoreType !== Kinvey.DataStoreType.Network) {
             return storeToTest.clearSync()
-              .then(() => done())
-          } else {
-            done();
+              .then(() => done());
           }
+          done();
+          return Promise.resolve();
         });
 
         it('should throw an error when trying to save an array of entities', (done) => {
@@ -884,14 +866,15 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal('Unable to create an array of entities.');
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should create a new entity without _id', (done) => {
           const newEntity = {
             [textFieldName]: utilities.randomString()
           };
-          
+
           storeToTest.save(newEntity)
             .then((createdEntity) => {
               expect(createdEntity._id).to.exist;
@@ -905,7 +888,7 @@ function testFunc() {
               return utilities.validateEntity(dataStoreType, collectionName, newEntity);
             })
             .then(() => {
-              return utilities.validatePendingSyncCount(dataStoreType, collectionName, 1)
+              return utilities.validatePendingSyncCount(dataStoreType, collectionName, 1);
             })
             .then(() => done())
             .catch(done);
@@ -937,22 +920,19 @@ function testFunc() {
             .then((updatedEntity) => {
               expect(updatedEntity._id).to.equal(entity1._id);
               expect(updatedEntity.newProperty).to.equal(entityToUpdate.newProperty);
-              return utilities.validateEntity(dataStoreType, collectionName, entityToUpdate, 'newProperty')
+              return utilities.validateEntity(dataStoreType, collectionName, entityToUpdate, 'newProperty');
             })
-            .then(() => {
-              return utilities.validatePendingSyncCount(dataStoreType, collectionName, 1)
-            })
+            .then(() => utilities.validatePendingSyncCount(dataStoreType, collectionName, 1))
             .then(() => done())
             .catch(done);
         });
       });
 
       describe('destroy operations', () => {
-
         before((done) => {
           utilities.cleanUpCollectionData(collectionName)
             .then(() => {
-              return utilities.saveEntities(collectionName, [entity1, entity2])
+              return utilities.saveEntities(collectionName, [entity1, entity2]);
             })
             .then(() => done())
             .catch(done);
@@ -965,10 +945,11 @@ function testFunc() {
                 if (dataStoreType === Kinvey.DataStoreType.Network) {
                   expect(error.name).to.contain(notFoundErrorName);
                 } else {
-                  expect(error).to.exist
+                  expect(error).to.exist;
                 }
                 done();
-              }).catch(done);
+              })
+              .catch(done);
           });
 
           it('should remove only the entity that matches the id argument', (done) => {
@@ -976,9 +957,7 @@ function testFunc() {
               _id: utilities.randomString()
             };
             storeToTest.save(newEntity)
-              .then(() => {
-                return storeToTest.removeById(newEntity._id)
-              })
+              .then(() => storeToTest.removeById(newEntity._id))
               .then((result) => {
                 expect(result.count).to.equal(1);
                 const onNextSpy = sinon.spy();
@@ -987,29 +966,30 @@ function testFunc() {
                 return storeToTest.count(query)
                   .subscribe(onNextSpy, done, () => {
                     try {
-                      utilities.validateReadResult(dataStoreType, onNextSpy, 0, 0)
+                      utilities.validateReadResult(dataStoreType, onNextSpy, 0, 0);
                       return storeToTest.count().toPromise()
                         .then((count) => {
                           expect(count).to.equal(2);
                           done();
-                        }).catch(done);
+                        })
+                        .catch(done);
                     } catch (error) {
                       done(error);
                     }
+                    return null;
                   });
               });
           });
         });
 
         describe('remove()', () => {
-
           before((done) => {
             if (dataStoreType !== Kinvey.DataStoreType.Network) {
               return storeToTest.clearSync()
-                .then(() => done())
-            } else {
-              done();
+                .then(() => done());
             }
+            done();
+            return Promise.resolve();
           });
 
           it('should throw an error for an invalid query', (done) => {
@@ -1017,7 +997,8 @@ function testFunc() {
               .catch((error) => {
                 expect(error.message).to.equal(invalidQueryMessage);
                 done();
-              }).catch(done);
+              })
+              .catch(done);
           });
 
           it('should remove all entities that match the query', (done) => {
@@ -1026,12 +1007,10 @@ function testFunc() {
             query.equalTo(textFieldName, newEntity[textFieldName]);
             let initialCount;
             utilities.saveEntities(collectionName, [newEntity, newEntity])
-              .then(() => {
-                return storeToTest.count().toPromise()
-              })
+              .then(() => storeToTest.count().toPromise())
               .then((count) => {
                 initialCount = count;
-                return storeToTest.remove(query)
+                return storeToTest.remove(query);
               })
               .then((result) => {
                 expect(result.count).to.equal(2);
@@ -1039,17 +1018,20 @@ function testFunc() {
                 return storeToTest.count(query)
                   .subscribe(onNextSpy, done, () => {
                     try {
-                      utilities.validateReadResult(dataStoreType, onNextSpy, 0, 0)
+                      utilities.validateReadResult(dataStoreType, onNextSpy, 0, 0);
                       return storeToTest.count().toPromise()
                         .then((count) => {
                           expect(count).to.equal(initialCount - 2);
                           done();
-                        }).catch(done);
+                        })
+                        .catch(done);
                     } catch (error) {
                       done(error);
                     }
+                    return null;
                   });
-              }).catch(done);
+              })
+              .catch(done);
           });
 
           it('should return a { count: 0 } when no entities are removed', (done) => {
@@ -1058,8 +1040,9 @@ function testFunc() {
             storeToTest.remove(query)
               .then((result) => {
                 expect(result.count).to.equal(0);
-                done()
-              }).catch(done);
+                done();
+              })
+              .catch(done);
           });
         });
       });

--- a/test/integration/crud-entity/offline-crud.test.js
+++ b/test/integration/crud-entity/offline-crud.test.js
@@ -1,57 +1,50 @@
 function testFunc() {
-
   const dataStoreTypes = [Kinvey.DataStoreType.Cache, Kinvey.DataStoreType.Sync];
   const notFoundErrorName = 'NotFoundError';
   const shouldNotBeCalledErrorMessage = 'Should not be called';
-  const collectionName = externalConfig.collectionName;
+  const { collectionName } = externalConfig;
 
   dataStoreTypes.forEach((currentDataStoreType) => {
     describe(`${currentDataStoreType} Store CRUD Specific Tests`, () => {
-
       let networkStore;
       let syncStore;
       let cacheStore;
       let storeToTest;
       const dataStoreType = currentDataStoreType;
       const entity1 = utilities.getEntity(utilities.randomString());
-      let createdUserIds = [];
+      const createdUserIds = [];
 
       before((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
-          .then(() => {
-            return Kinvey.User.signup()
-          })
+          .then(() => Kinvey.User.signup())
           .then((user) => {
             createdUserIds.push(user.data._id);
-            //store for setup
+            // store for setup
             networkStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Network);
             syncStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Sync);
             cacheStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Cache);
-            //store to test
+            // store to test
             storeToTest = Kinvey.DataStore.collection(collectionName, dataStoreType);
             done();
           })
-          .catch(done)
+          .catch(done);
       });
 
       beforeEach((done) => {
         utilities.cleanUpCollectionData(collectionName)
-          .then(() => {
-            return cacheStore.save(entity1)
-          })
+          .then(() => cacheStore.save(entity1))
           .then(() => done())
-          .catch(done)
+          .catch(done);
       });
 
       after((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
           .then(() => done())
-          .catch(done)
+          .catch(done);
       });
 
       if (dataStoreType === Kinvey.DataStoreType.Cache) {
         describe('local cache removal', () => {
-
           it('find() should remove entities that no longer exist in the backend from the cache', (done) => {
             const entity = utilities.getEntity(utilities.randomString());
             storeToTest.save(entity)
@@ -73,15 +66,11 @@ function testFunc() {
           it.skip('findById() should remove entities that no longer exist on the backend from the cache', (done) => {
             const entity = utilities.getEntity(utilities.randomString());
             storeToTest.save(entity)
-              .then((entity) => {
-                return networkStore.removeById(entity._id)
-              })
-              .then(() => {
-                return storeToTest.findById(entity._id).toPromise()
-              })
+              .then((entity) => networkStore.removeById(entity._id))
+              .then(() => storeToTest.findById(entity._id).toPromise())
               .catch((error) => {
                 expect(error.name).to.equal(notFoundErrorName);
-                return syncStore.findById(entity._id).toPromise()
+                return syncStore.findById(entity._id).toPromise();
               })
               .then(() => {
                 done(new Error(shouldNotBeCalledErrorMessage));
@@ -92,7 +81,7 @@ function testFunc() {
                   .then((count) => {
                     expect(count).to.equal(1);
                     done();
-                  })
+                  });
               })
               .catch(done);
           });
@@ -100,15 +89,11 @@ function testFunc() {
           it('removeById should remove the entity from cache even if the entity is not found on the backend', (done) => {
             const entity = utilities.getEntity(utilities.randomString());
             storeToTest.save(entity)
-              .then((entity) => {
-                return networkStore.removeById(entity._id)
-              })
-              .then(() => {
-                return storeToTest.removeById(entity._id)
-              })
+              .then((entity) => networkStore.removeById(entity._id))
+              .then(() => storeToTest.removeById(entity._id))
               .then((result) => {
                 expect(result.count).to.equal(1);
-                return syncStore.findById(entity._id).toPromise()
+                return syncStore.findById(entity._id).toPromise();
               })
               .then(() => {
                 return done(new Error(shouldNotBeCalledErrorMessage));
@@ -123,46 +108,45 @@ function testFunc() {
       }
 
       describe('clear()', () => {
-
         it('should remove the entities from the cache, which match the query', (done) => {
           const randomId = utilities.randomString();
-          cacheStore.save({ '_id': randomId })
+          cacheStore.save({ _id: randomId })
             .then(() => {
               const query = new Kinvey.Query();
               query.equalTo('_id', randomId);
-              return storeToTest.clear(query)
+              return storeToTest.clear(query);
             })
             .then((result) => {
               expect(result.count).to.equal(1);
-              return syncStore.count().toPromise()
+              return syncStore.count().toPromise();
             })
             .then((count) => {
               expect(count).to.equal(1);
-              return networkStore.count().toPromise()
+              return networkStore.count().toPromise();
             })
             .then((count) => {
               expect(count).to.equal(2);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should remove all entities only from the cache', (done) => {
           cacheStore.save({})
-            .then(() => {
-              return storeToTest.clear()
-            })
+            .then(() => storeToTest.clear())
             .then((result) => {
               expect(result.count).to.equal(2);
-              return syncStore.count().toPromise()
+              return syncStore.count().toPromise();
             })
             .then((count) => {
               expect(count).to.equal(0);
-              return networkStore.count().toPromise()
+              return networkStore.count().toPromise();
             })
             .then((count) => {
               expect(count).to.equal(2);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
       });
     });

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -3,4 +3,4 @@ before(() => {
     appKey: externalConfig.appKey,
     appSecret: externalConfig.appSecret
   });
-})
+});

--- a/test/integration/sync.test.js
+++ b/test/integration/sync.test.js
@@ -1,5 +1,4 @@
 function testFunc() {
-
   const dataStoreTypes = [Kinvey.DataStoreType.Cache, Kinvey.DataStoreType.Sync];
   let networkStore;
   let syncStore;
@@ -8,7 +7,7 @@ function testFunc() {
   const notFoundErrorName = 'NotFoundError';
   const collectionName = externalConfig.collectionName;
 
-  //validates Push operation result for 1 created, 1 modified and 1 deleted locally items
+  // validates Push operation result for 1 created, 1 modified and 1 deleted locally items
   const validatePushOperation = (result, createdItem, modifiedItem, deletedItem, expectedServerItemsCount) => {
     expect(result.length).to.equal(3);
     result.forEach((record) => {
@@ -21,7 +20,7 @@ function testFunc() {
       } else {
         expect(record.entity).to.not.exist;
       }
-    })
+    });
     networkStore.find().toPromise()
       .then((result) => {
         expect(result.length).to.equal(expectedServerItemsCount);
@@ -30,77 +29,68 @@ function testFunc() {
         const createdOnServer = _.find(result, e => e._id === createdItem._id);
 
         expect(utilities.deleteEntityMetadata(createdOnServer)).to.deep.equal(createdItem);
-        return storeToTest.pendingSyncCount()
+        return storeToTest.pendingSyncCount();
       })
       .then((count) => {
         expect(count).to.equal(0);
       });
-  }
-  //validates Pull operation result
+  };
+
+  // validates Pull operation result
   const validatePullOperation = (result, expectedItems, expectedPulledItemsCount) => {
     expect(result.length).to.equal(expectedPulledItemsCount || expectedItems.length);
     expectedItems.forEach((entity) => {
       const resultEntity = _.find(result, e => e._id === entity._id);
       expect(utilities.deleteEntityMetadata(resultEntity)).to.deep.equal(entity);
-    })
+    });
 
     return syncStore.find().toPromise()
       .then((result) => {
         expectedItems.forEach((entity) => {
           const cachedEntity = _.find(result, e => e._id === entity._id);
           expect(utilities.deleteEntityMetadata(cachedEntity)).to.deep.equal(entity);
-        })
+        });
       });
-  }
+  };
 
   dataStoreTypes.forEach((currentDataStoreType) => {
     describe(`${currentDataStoreType} Sync Tests`, () => {
-
       const dataStoreType = currentDataStoreType;
       const entity1 = utilities.getEntity(utilities.randomString());
       const entity2 = utilities.getEntity(utilities.randomString());
       const entity3 = utilities.getEntity(utilities.randomString());
-      let createdUserIds = [];
+      const createdUserIds = [];
 
       before((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
-          .then(() => {
-            return Kinvey.User.signup()
-          })
+          .then(() => Kinvey.User.signup())
           .then((user) => {
             createdUserIds.push(user.data._id);
-            //store for setup
+            // store for setup
             networkStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Network);
             syncStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Sync);
             cacheStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Cache);
-            //store to test
+            // store to test
             storeToTest = Kinvey.DataStore.collection(collectionName, dataStoreType);
             done();
           })
-          .catch(done)
-      })
+          .catch(done);
+      });
 
       after((done) => {
         utilities.cleanUpAppData(collectionName, createdUserIds)
           .then(() => done())
-          .catch(done)
+          .catch(done);
       });
 
       describe('Pending sync queue operations', () => {
-
         beforeEach((done) => {
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => {
-              return syncStore.save(entity1)
-            })
-            .then(() => {
-              return syncStore.save(entity2)
-            })
-            .then(() => {
-              return cacheStore.save(entity3)
-            })
+            .then(() => syncStore.save(entity1))
+            .then(() => syncStore.save(entity2))
+            .then(() => cacheStore.save(entity3))
             .then(() => done())
-            .catch(done)
+            .catch(done);
         });
 
         it('pendingSyncCount() should return the count of the entities waiting to be synced', (done) => {
@@ -123,9 +113,7 @@ function testFunc() {
 
         it('clearSync() should clear the pending sync queue', (done) => {
           syncStore.clearSync()
-            .then(() => {
-              return storeToTest.pendingSyncCount()
-            })
+            .then(() => storeToTest.pendingSyncCount())
             .then((count) => {
               expect(count).to.equal(0);
               done();
@@ -136,9 +124,7 @@ function testFunc() {
           const query = new Kinvey.Query();
           query.equalTo('_id', entity1._id);
           syncStore.clearSync(query)
-            .then(() => {
-              return storeToTest.pendingSyncEntities()
-            })
+            .then(() => storeToTest.pendingSyncEntities())
             .then((result) => {
               expect(result.length).to.equal(1);
               expect(result[0].entityId).to.equal(entity2._id);
@@ -154,7 +140,7 @@ function testFunc() {
                 expect(entity.collection).to.equal(externalConfig.collectionName);
                 expect(entity.state.operation).to.equal('PUT');
                 expect([entity1._id, entity2._id]).to.include(entity.entityId);
-              })
+              });
               done();
             }).catch(done);
         });
@@ -172,9 +158,7 @@ function testFunc() {
 
         it('pendingSyncEntities() should return an empty array if there are no entities waiting to be synced', (done) => {
           syncStore.clearSync()
-            .then(() => {
-              return storeToTest.pendingSyncEntities()
-            })
+            .then(() => storeToTest.pendingSyncEntities())
             .then((entities) => {
               expect(entities).to.be.an.empty.array;
               done();
@@ -183,42 +167,26 @@ function testFunc() {
       });
 
       describe('Sync operations', () => {
-
         let updatedEntity2;
 
         beforeEach((done) => {
           updatedEntity2 = Object.assign({ newProperty: utilities.randomString() }, entity2);
-          //adding three items, eligible for sync and one item, which should not be synced
+          // adding three items, eligible for sync and one item, which should not be synced
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => {
-              return syncStore.save(entity1)
-            })
-            .then(() => {
-              return cacheStore.save(entity2)
-            })
-            .then(() => {
-              return cacheStore.save(entity3)
-            })
-            .then(() => {
-              return syncStore.save(updatedEntity2)
-            })
-            .then(() => {
-              return syncStore.removeById(entity3._id)
-            })
-            .then(() => {
-              return cacheStore.save({})
-            })
+            .then(() => syncStore.save(entity1))
+            .then(() => cacheStore.save(entity2))
+            .then(() => cacheStore.save(entity3))
+            .then(() => syncStore.save(updatedEntity2))
+            .then(() => syncStore.removeById(entity3._id))
+            .then(() => cacheStore.save({}))
             .then(() => done())
-            .catch(done)
+            .catch(done);
         });
 
         describe('push()', () => {
-
           it('should push created/updated/deleted locally entities to the backend', (done) => {
             storeToTest.push()
-              .then((result) => {
-                return validatePushOperation(result, entity1, updatedEntity2, entity3, 3)
-              })
+              .then((result) => validatePushOperation(result, entity1, updatedEntity2, entity3, 3))
               .then(done)
               .catch(done);
           });
@@ -236,52 +204,45 @@ function testFunc() {
                     expect(_.find(result, (entity) => { return entity._id === entity1._id; })).to.exist;
                     expect(_.find(result, (entity) => { return entity._id === entity3._id; })).to.exist;
                     done();
-                  })
-              }).catch(done);
+                  });
+              })
+              .catch(done);
           });
 
           it('should log an error, finish the push and not clear the sync queue if an item push fails', (done) => {
             networkStore.removeById(entity3._id)
-              .then(() => {
-                return storeToTest.push()
-              })
+              .then(() => storeToTest.push())
               .then((result) => {
                 expect(result.length).to.equal(3);
                 const errorRecord = _.find(result, (entity) => { return entity._id === entity3._id; });
                 expect(errorRecord.error.name).to.equal(notFoundErrorName);
-                return networkStore.find().toPromise()
+                return networkStore.find().toPromise();
               })
               .then((result) => {
                 expect(_.find(result, (entity) => { return entity.newProperty === updatedEntity2.newProperty; })).to.exist;
                 expect(_.find(result, (entity) => { return entity._id === entity1._id; })).to.exist;
-                return storeToTest.pendingSyncCount()
+                return storeToTest.pendingSyncCount();
               })
               .then((count) => {
                 expect(count).to.equal(1);
-                done()
-              }).catch(done);
+                done();
+              })
+              .catch(done);
           });
         });
 
         describe('pull()', () => {
-
           beforeEach((done) => {
             utilities.cleanUpCollectionData(collectionName)
-              .then(() => {
-                return networkStore.save(entity1)
-              })
-              .then(() => {
-                return networkStore.save(entity2)
-              })
+              .then(() => networkStore.save(entity1))
+              .then(() => networkStore.save(entity2))
               .then(() => done())
-              .catch(done)
+              .catch(done);
           });
 
           it('should save the entities from the backend in the cache', (done) => {
             storeToTest.pull()
-              .then((result) => {
-                return validatePullOperation(result, [entity1, entity2])
-              })
+              .then((result) => validatePullOperation(result, [entity1, entity2]))
               .then(() => done())
               .catch(done);
           });
@@ -290,29 +251,24 @@ function testFunc() {
             const query = new Kinvey.Query();
             query.equalTo('_id', entity1._id);
             storeToTest.pull(query)
-              .then((result) => {
-                return validatePullOperation(result, [entity1])
-              })
+              .then((result) => validatePullOperation(result, [entity1]))
               .then(() => done())
               .catch(done);
           });
         });
 
         describe('sync()', () => {
-
           let serverEntity1;
           let serverEntity2;
 
           beforeEach((done) => {
-            //creating two server items - three items, eligible for sync are already created in cache
+            // creating two server items - three items, eligible for sync are already created in cache
             serverEntity1 = utilities.getEntity(utilities.randomString());
             serverEntity2 = utilities.getEntity(utilities.randomString());
             networkStore.save(serverEntity1)
-              .then(() => {
-                return networkStore.save(serverEntity2)
-              })
+              .then(() => networkStore.save(serverEntity2))
               .then(() => done())
-              .catch(done)
+              .catch(done);
           });
 
           it('should push and then pull the entities from the backend in the cache', (done) => {
@@ -320,11 +276,9 @@ function testFunc() {
             storeToTest.sync()
               .then((result) => {
                 syncResult = result;
-                return validatePushOperation(syncResult.push, entity1, updatedEntity2, entity3, 5)
+                return validatePushOperation(syncResult.push, entity1, updatedEntity2, entity3, 5);
               })
-              .then(() => {
-                return validatePullOperation(syncResult.pull, [serverEntity1, serverEntity2, updatedEntity2], 5)
-              })
+              .then(() => validatePullOperation(syncResult.pull, [serverEntity1, serverEntity2, updatedEntity2], 5))
               .then(() => done())
               .catch(done);
           });
@@ -335,14 +289,14 @@ function testFunc() {
             query.equalTo('_id', updatedEntity2._id);
             storeToTest.sync(query)
               .then((result) => {
-                syncResult = result
+                syncResult = result;
                 expect(syncResult.push.length).to.equal(1);
                 expect(syncResult.push[0]._id).to.equal(updatedEntity2._id);
-                return networkStore.find().toPromise()
+                return networkStore.find().toPromise();
               })
               .then((result) => {
                 expect(_.find(result, (entity) => { return entity._id === updatedEntity2._id; })).to.exist;
-                return validatePullOperation(syncResult.pull, [updatedEntity2])
+                return validatePullOperation(syncResult.pull, [updatedEntity2]);
               })
               .then(() => done())
               .catch(done);

--- a/test/integration/users/users.tests.js
+++ b/test/integration/users/users.tests.js
@@ -1,6 +1,5 @@
 function testFunc() {
-
-  const collectionName = externalConfig.collectionName;
+  const { collectionName } = externalConfig;
   const assertUserData = (user, expectedUsername, shouldReturnPassword) => {
     expect(user.data._id).to.exist;
     expect(user.metadata.authtoken).to.exist;
@@ -17,15 +16,14 @@ function testFunc() {
     }
     expect(user.isActive()).to.equal(true);
     expect(user).to.deep.equal(Kinvey.User.getActiveUser());
-  }
+  };
 
   const getMissingUsernameErrorMessage = 'A username was not provided.';
-
   const getMissingEmailErrorMessage = 'An email was not provided.';
 
   const getNotAStringErrorMessage = (parameter) => {
     return `The provided ${parameter} is not a string.`;
-  }
+  };
 
   const safelySignUpUser = (username, password, state, createdUserIds) => {
     return Kinvey.User.logout()
@@ -34,38 +32,34 @@ function testFunc() {
           username: username,
           password: password,
           email: utilities.randomEmailAddress()
-        }, {
-            state: state
-          })
+        }, { state: state });
       })
       .then((user) => {
         createdUserIds.push(user.data._id);
         return user;
-      })
-  }
+      });
+  };
 
   describe('User tests', () => {
-
     const missingCredentialsError = 'Username and/or password missing';
-    let createdUserIds = [];
+    const createdUserIds = [];
 
     before((done) => {
       utilities.cleanUpAppData(collectionName, createdUserIds)
         .then(() => done())
-        .catch(done)
+        .catch(done);
     });
 
     after((done) => {
       utilities.cleanUpAppData(collectionName, createdUserIds)
         .then(() => done())
-        .catch(done)
+        .catch(done);
     });
 
     describe('login()', () => {
-
       beforeEach((done) => {
         Kinvey.User.logout()
-          .then(() => done())
+          .then(() => done());
       });
 
       it('should throw an error if an active user already exists', (done) => {
@@ -77,7 +71,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain('An active user already exists.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if a username is not provided', (done) => {
@@ -85,7 +80,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain(missingCredentialsError);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if the username is an empty string', (done) => {
@@ -93,7 +89,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain(missingCredentialsError);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if a password is not provided', (done) => {
@@ -101,7 +98,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain(missingCredentialsError);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if the password is an empty string', (done) => {
@@ -109,7 +107,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain(missingCredentialsError);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if the username and/or password is invalid', (done) => {
@@ -118,7 +117,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain('Invalid credentials.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should login a user', (done) => {
@@ -127,15 +127,14 @@ function testFunc() {
         Kinvey.User.signup({ username: username, password: password })
           .then((user) => {
             createdUserIds.push(user.data._id);
-            return Kinvey.User.logout()
+            return Kinvey.User.logout();
           })
-          .then(() => {
-            return Kinvey.User.login(username, password)
-          })
+          .then(() => Kinvey.User.login(username, password))
           .then((user) => {
             assertUserData(user, username);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should login a user by providing credentials as an object', (done) => {
@@ -144,15 +143,14 @@ function testFunc() {
         Kinvey.User.signup({ username: username, password: password })
           .then((user) => {
             createdUserIds.push(user.data._id);
-            return Kinvey.User.logout()
+            return Kinvey.User.logout();
           })
-          .then(() => {
-            return Kinvey.User.login({ username: username, password: password })
-          })
+          .then(() => Kinvey.User.login({ username: username, password: password }))
           .then((user) => {
             assertUserData(user, username);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
@@ -164,9 +162,7 @@ function testFunc() {
       before((done) => {
         syncDataStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Sync);
         safelySignUpUser(username, password, true, createdUserIds)
-          .then(() => {
-            return syncDataStore.save({ field: 'value' })
-          })
+          .then(() => syncDataStore.save({ field: 'value' }))
           .then(() => done())
           .catch(done);
       });
@@ -177,24 +173,23 @@ function testFunc() {
           .then((user) => {
             expect(user.isActive()).to.equal(false);
             expect(Kinvey.User.getActiveUser()).to.equal(null);
-            return Kinvey.User.signup()
+            return Kinvey.User.signup();
           })
           .then((user) => {
             createdUserIds.push(user.data._id);
             const dataStore = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Sync);
-            return dataStore.find().toPromise()
+            return dataStore.find().toPromise();
           })
           .then((entities) => {
             expect(entities).to.deep.equal([]);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should logout when there is not an active user', (done) => {
         Kinvey.User.logout()
-          .then(() => {
-            return Kinvey.User.logout()
-          })
+          .then(() => Kinvey.User.logout())
           .then(() => {
             expect(Kinvey.User.getActiveUser()).to.equal(null);
           })
@@ -206,7 +201,7 @@ function testFunc() {
     describe('signup', () => {
       beforeEach((done) => {
         Kinvey.User.logout()
-          .then(() => done())
+          .then(() => done());
       });
 
       it('should signup and set the user as the active user', (done) => {
@@ -217,7 +212,8 @@ function testFunc() {
             createdUserIds.push(user.data._id);
             assertUserData(user, username, true);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should signup with a user and set the user as the active user', (done) => {
@@ -228,7 +224,8 @@ function testFunc() {
             createdUserIds.push(user.data._id);
             assertUserData(user, username, true);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should signup with attributes and store them correctly', (done) => {
@@ -237,7 +234,8 @@ function testFunc() {
           password: utilities.randomString(),
           email: utilities.randomEmailAddress(),
           additionalField: 'test'
-        }
+        };
+
         Kinvey.User.signup(data)
           .then((user) => {
             createdUserIds.push(user.data._id);
@@ -245,7 +243,8 @@ function testFunc() {
             expect(user.data.email).to.equal(data.email);
             expect(user.data.additionalField).to.equal(data.additionalField);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should signup user and not set the user as the active user if options.state = false', (done) => {
@@ -254,16 +253,18 @@ function testFunc() {
             createdUserIds.push(user.data._id);
             expect(user.isActive()).to.equal(false);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should signup an implicit user and set the user as the active user', (done) => {
         Kinvey.User.signup()
           .then((user) => {
             createdUserIds.push(user.data._id);
-            assertUserData(user, null, true)
+            assertUserData(user, null, true);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should merge the signup data and set the user as the active user', (done) => {
@@ -283,7 +284,8 @@ function testFunc() {
             expect(user.data.password).to.equal(password);
             expect(user).to.deep.equal(Kinvey.User.getActiveUser());
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw an error if an active user already exists', (done) => {
@@ -295,7 +297,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.contain('An active user already exists.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should not throw an error with an active user and options.state set to false', (done) => {
@@ -305,16 +308,15 @@ function testFunc() {
             return Kinvey.User.signup({
               username: utilities.randomString(),
               password: utilities.randomString()
-            }, {
-                state: false
-              })
+            }, { state: false });
           })
           .then((user) => {
             createdUserIds.push(user.data._id);
             expect(user.isActive()).to.equal(false);
             expect(user).to.not.equal(Kinvey.User.getActiveUser());
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
@@ -339,19 +341,15 @@ function testFunc() {
             expect(user.data.email).to.equal(newEmail);
             const query = new Kinvey.Query();
             query.equalTo('email', newEmail);
-            return Kinvey.User.lookup(query).toPromise()
+            return Kinvey.User.lookup(query).toPromise();
           })
           .then((users) => {
             expect(users.length).to.equal(1);
             expect(users[0].email).to.equal(newEmail);
-            return Kinvey.User.logout()
+            return Kinvey.User.logout();
           })
-          .then(() => {
-            return Kinvey.User.login(username, newPassword)
-          })
-          .then(() => {
-            done();
-          })
+          .then(() => Kinvey.User.login(username, newPassword))
+          .then(() => done())
           .catch(done);
       });
 
@@ -363,7 +361,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.equal('User must have an _id.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
@@ -382,7 +381,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.equal('Invalid query. It must be an instance of the Query class.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should return an array of users matching the query', (done) => {
@@ -397,30 +397,27 @@ function testFunc() {
             expect(user._id).to.exist;
             expect(user.username).to.equal(username);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
     describe('remove()', () => {
       let userToRemoveId1;
       let userToRemoveId2;
-      let username1 = utilities.randomString();
-      let username2 = utilities.randomString();
+      const username1 = utilities.randomString();
+      const username2 = utilities.randomString();
 
       before((done) => {
         safelySignUpUser(username1, null, false, createdUserIds)
           .then((user) => {
             userToRemoveId1 = user.data._id;
           })
-          .then(() => {
-            return Kinvey.User.signup({ username: username2 }, { state: false })
-          })
+          .then(() => Kinvey.User.signup({ username: username2 }, { state: false }))
           .then((user) => {
             userToRemoveId2 = user.data._id;
           })
-          .then(() => {
-            return Kinvey.User.signup()
-          })
+          .then(() => Kinvey.User.signup())
           .then((user) => {
             createdUserIds.push(user.data._id);
             done();
@@ -433,7 +430,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.equal('An id was not provided.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should throw a KinveyError if an id is not a string', (done) => {
@@ -441,7 +439,8 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.equal('The id provided is not a string.');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should return the error from the server if the id does not exist', (done) => {
@@ -449,35 +448,34 @@ function testFunc() {
           .catch((error) => {
             expect(error.message).to.equal('This user does not exist for this app backend');
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should remove the user that matches the id argument, but the user should remain in the Backend', (done) => {
         Kinvey.User.remove(userToRemoveId1)
-          .then(() => {
-            return Kinvey.User.exists(username1)
-          })
+          .then(() => Kinvey.User.exists(username1))
           .then((result) => {
-            expect(result).to.be.true
+            expect(result).to.be.true;
             const query = new Kinvey.Query();
             query.equalTo('username', username1);
-            return Kinvey.User.lookup(query).toPromise()
+            return Kinvey.User.lookup(query).toPromise();
           })
           .then((users) => {
             expect(users.length).to.equal(0);
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should remove the user that matches the id argument permanently', (done) => {
         Kinvey.User.remove(userToRemoveId2, { hard: true })
-          .then(() => {
-            return Kinvey.User.exists(username2)
-          })
+          .then(() => Kinvey.User.exists(username2))
           .then((result) => {
-            expect(result).to.be.false
+            expect(result).to.be.false;
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
@@ -493,17 +491,19 @@ function testFunc() {
       it('should return true if the user exists in the Backend', (done) => {
         Kinvey.User.exists(username)
           .then((result) => {
-            expect(result).to.be.true
+            expect(result).to.be.true;
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
 
       it('should return false if the user does not exist in the Backend', (done) => {
         Kinvey.User.exists(utilities.randomString())
           .then((result) => {
-            expect(result).to.be.false
+            expect(result).to.be.false;
             done();
-          }).catch(done);
+          })
+          .catch(done);
       });
     });
 
@@ -521,17 +521,17 @@ function testFunc() {
       });
 
       describe('verifyEmail()', () => {
-
         it('should start the email verification and User.me should get the updated user from the server', (done) => {
           Kinvey.User.verifyEmail(username)
             .then(() => {
               // Kinvey.User.me() is used to get the created emailVerification field from the server
-              return Kinvey.User.me()
+              return Kinvey.User.me();
             })
             .then((user) => {
               expect(user.metadata.emailVerification).to.exist;
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if a username is not provided', (done) => {
@@ -539,7 +539,8 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getMissingUsernameErrorMessage);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if the provided username is not a string', (done) => {
@@ -547,18 +548,19 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getNotAStringErrorMessage('username'));
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
       });
 
       describe('forgotUsername()', () => {
-
         it('should start the email sending process on the server', (done) => {
           Kinvey.User.forgotUsername(email)
             .then((result) => {
               expect(['', null]).to.include(result);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if an email is not provided', (done) => {
@@ -566,7 +568,8 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getMissingEmailErrorMessage);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if the provided email is not a string', (done) => {
@@ -574,18 +577,19 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getNotAStringErrorMessage('email'));
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
       });
 
       describe('resetPassword()', () => {
-
         it('should start the reset password procedure on the server', (done) => {
           Kinvey.User.resetPassword(username)
             .then((result) => {
               expect(['', null]).to.include(result);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if a username is not provided', (done) => {
@@ -593,7 +597,8 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getMissingUsernameErrorMessage);
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
 
         it('should throw an error if the provided username is not a string', (done) => {
@@ -601,7 +606,8 @@ function testFunc() {
             .catch((error) => {
               expect(error.message).to.equal(getNotAStringErrorMessage('username'));
               done();
-            }).catch(done);
+            })
+            .catch(done);
         });
       });
     });


### PR DESCRIPTION
#### Description
This fixes linting errors in the integration tests. Part of [QA-135](https://kinvey.atlassian.net/browse/QA-135).

#### Changes
Extended `.eslintrc` for the integration tests folder, declaring some globally used variables and turning off some rules, which IMO either didn't make sense or were incompatible with `chai`. Fixed linting errors in test files and utility files for tests. Removed a couple of unused variables from `runner-config.js` and fixed indentation.
