### PR TITLE
MLIBZ-2156: Correctly sort fields that have a null value

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -783,9 +783,9 @@ export class Query {
             } else if (isDefined(aField) === false && isDefined(bField)) {
               return -1 * modifier;
             } else if (typeof aField === 'undefined' && bField === null) {
-              return -1 * modifier;
+              return 0;
             } else if (aField === null && typeof bField === 'undefined') {
-              return 1 * modified;
+              return 0;
             } else if (aField !== bField) {
               return (aField < bField ? -1 : 1) * modifier;
             }

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -778,9 +778,9 @@ export class Query {
             const bField = nested(b, field);
 
             if (isDefined(aField) && isDefined(bField) === false) {
-              return -1;
-            } else if (isDefined(bField) && isDefined(aField) === false) {
               return 1;
+            } else if (isDefined(bField) && isDefined(aField) === false) {
+              return -1;
             } else if (aField !== bField) {
               const modifier = json.sort[field]; // 1 or -1.
               return (aField < bField ? -1 : 1) * modifier;

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -776,13 +776,17 @@ export class Query {
             // Find field in objects.
             const aField = nested(a, field);
             const bField = nested(b, field);
+            const modifier = json.sort[field]; // 1 (ascending) or -1 (descending).
 
             if (isDefined(aField) && isDefined(bField) === false) {
-              return 1;
-            } else if (isDefined(bField) && isDefined(aField) === false) {
-              return -1;
+              return 1 * modifier;
+            } else if (isDefined(aField) === false && isDefined(bField)) {
+              return -1 * modifier;
+            } else if (typeof aField === 'undefined' && bField === null) {
+              return -1 * modifier;
+            } else if (aField === null && typeof bField === 'undefined') {
+              return 1 * modified;
             } else if (aField !== bField) {
-              const modifier = json.sort[field]; // 1 or -1.
               return (aField < bField ? -1 : 1) * modifier;
             }
           }

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -940,13 +940,15 @@ describe('Query', () => {
       const entity2 = { _id: null, customProperty: randomString() };
       const entity3 = { _id: 2, customProperty: randomString() };
       const entity4 = { customProperty: randomString() };
+      const entity5 = { _id: null, customProperty: randomString() };
       const query = new Query().ascending('_id');
       query.fields = ['customProperty'];
-      const result = query.process([entity4, entity1, entity3, entity2]);
-      expect(result[0].customProperty).to.equal(entity4.customProperty);
-      expect(result[1].customProperty).to.equal(entity2.customProperty);
-      expect(result[2].customProperty).to.equal(entity1.customProperty);
-      expect(result[3].customProperty).to.equal(entity3.customProperty);
+      const result = query.process([entity5, entity4, entity1, entity3, entity2]);
+      expect(result[0].customProperty).to.equal(entity5.customProperty);
+      expect(result[1].customProperty).to.equal(entity4.customProperty);
+      expect(result[2].customProperty).to.equal(entity2.customProperty);
+      expect(result[3].customProperty).to.equal(entity1.customProperty);
+      expect(result[4].customProperty).to.equal(entity3.customProperty);
     });
   });
 
@@ -993,13 +995,15 @@ describe('Query', () => {
       const entity2 = { _id: null, customProperty: randomString() };
       const entity3 = { _id: 2, customProperty: randomString() };
       const entity4 = { customProperty: randomString() };
+      const entity5 = { _id: null, customProperty: randomString() };
       const query = new Query().descending('_id');
       query.fields = ['customProperty'];
-      const result = query.process([entity4, entity1, entity3, entity2]);
+      const result = query.process([entity5, entity4, entity1, entity3, entity2]);
       expect(result[0].customProperty).to.equal(entity3.customProperty);
       expect(result[1].customProperty).to.equal(entity1.customProperty);
-      expect(result[2].customProperty).to.equal(entity2.customProperty);
+      expect(result[2].customProperty).to.equal(entity5.customProperty);
       expect(result[3].customProperty).to.equal(entity4.customProperty);
+      expect(result[4].customProperty).to.equal(entity2.customProperty);
     });
   });
 

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -941,10 +941,11 @@ describe('Query', () => {
       const entity3 = { _id: 2, customProperty: randomString() };
       const entity4 = { customProperty: randomString() };
       const query = new Query().ascending('_id');
-      query.fields = ['customProperty'];
+      // query.fields = ['customProperty'];
       const result = query.process([entity4, entity1, entity3, entity2]);
-      expect(result[0].customProperty).to.equal(entity2.customProperty);
-      expect(result[1].customProperty).to.equal(entity4.customProperty);
+      console.log(result);
+      expect(result[0].customProperty).to.equal(entity4.customProperty);
+      expect(result[1].customProperty).to.equal(entity2.customProperty);
       expect(result[2].customProperty).to.equal(entity1.customProperty);
       expect(result[3].customProperty).to.equal(entity3.customProperty);
     });
@@ -988,7 +989,7 @@ describe('Query', () => {
       expect(result[1].customProperty).to.equal(entity1.customProperty);
     });
 
-    it('should put docs with null or undefined values for sort field at the beginning of the list', () => {
+    it('should put docs with null or undefined values for sort field at the end of the list', () => {
       const entity1 = { _id: 1, customProperty: randomString() };
       const entity2 = { _id: null, customProperty: randomString() };
       const entity3 = { _id: 2, customProperty: randomString() };
@@ -996,10 +997,10 @@ describe('Query', () => {
       const query = new Query().descending('_id');
       query.fields = ['customProperty'];
       const result = query.process([entity4, entity1, entity3, entity2]);
-      expect(result[0].customProperty).to.equal(entity4.customProperty);
-      expect(result[1].customProperty).to.equal(entity2.customProperty);
-      expect(result[2].customProperty).to.equal(entity3.customProperty);
-      expect(result[3].customProperty).to.equal(entity1.customProperty);
+      expect(result[0].customProperty).to.equal(entity3.customProperty);
+      expect(result[1].customProperty).to.equal(entity1.customProperty);
+      expect(result[2].customProperty).to.equal(entity2.customProperty);
+      expect(result[3].customProperty).to.equal(entity4.customProperty);
     });
   });
 

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -941,9 +941,8 @@ describe('Query', () => {
       const entity3 = { _id: 2, customProperty: randomString() };
       const entity4 = { customProperty: randomString() };
       const query = new Query().ascending('_id');
-      // query.fields = ['customProperty'];
+      query.fields = ['customProperty'];
       const result = query.process([entity4, entity1, entity3, entity2]);
-      console.log(result);
       expect(result[0].customProperty).to.equal(entity4.customProperty);
       expect(result[1].customProperty).to.equal(entity2.customProperty);
       expect(result[2].customProperty).to.equal(entity1.customProperty);

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -934,6 +934,20 @@ describe('Query', () => {
       expect(result[0].customProperty).to.equal(entity1.customProperty);
       expect(result[1].customProperty).to.equal(entity2.customProperty);
     });
+
+    it('should put docs with null values for sort field at the beginning of the list', () => {
+      const entity1 = { _id: 1, customProperty: randomString() };
+      const entity2 = { _id: null, customProperty: randomString() };
+      const entity3 = { _id: 2, customProperty: randomString() };
+      const entity4 = { _id: 3, customProperty: randomString() };
+      const query = new Query().ascending('_id');
+      query.fields = ['customProperty'];
+      const result = query.process([entity4, entity1, entity3, entity2]);
+      expect(result[0].customProperty).to.equal(entity2.customProperty);
+      expect(result[1].customProperty).to.equal(entity1.customProperty);
+      expect(result[2].customProperty).to.equal(entity3.customProperty);
+      expect(result[3].customProperty).to.equal(entity4.customProperty);
+    });
   });
 
   describe('descending()', () => {

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -935,18 +935,18 @@ describe('Query', () => {
       expect(result[1].customProperty).to.equal(entity2.customProperty);
     });
 
-    it('should put docs with null values for sort field at the beginning of the list', () => {
+    it('should put docs with null or undefined values for sort field at the beginning of the list', () => {
       const entity1 = { _id: 1, customProperty: randomString() };
       const entity2 = { _id: null, customProperty: randomString() };
       const entity3 = { _id: 2, customProperty: randomString() };
-      const entity4 = { _id: 3, customProperty: randomString() };
+      const entity4 = { customProperty: randomString() };
       const query = new Query().ascending('_id');
       query.fields = ['customProperty'];
       const result = query.process([entity4, entity1, entity3, entity2]);
       expect(result[0].customProperty).to.equal(entity2.customProperty);
-      expect(result[1].customProperty).to.equal(entity1.customProperty);
-      expect(result[2].customProperty).to.equal(entity3.customProperty);
-      expect(result[3].customProperty).to.equal(entity4.customProperty);
+      expect(result[1].customProperty).to.equal(entity4.customProperty);
+      expect(result[2].customProperty).to.equal(entity1.customProperty);
+      expect(result[3].customProperty).to.equal(entity3.customProperty);
     });
   });
 
@@ -986,6 +986,20 @@ describe('Query', () => {
       const result = query.process([entity1, entity2]);
       expect(result[0].customProperty).to.equal(entity2.customProperty);
       expect(result[1].customProperty).to.equal(entity1.customProperty);
+    });
+
+    it('should put docs with null or undefined values for sort field at the beginning of the list', () => {
+      const entity1 = { _id: 1, customProperty: randomString() };
+      const entity2 = { _id: null, customProperty: randomString() };
+      const entity3 = { _id: 2, customProperty: randomString() };
+      const entity4 = { customProperty: randomString() };
+      const query = new Query().descending('_id');
+      query.fields = ['customProperty'];
+      const result = query.process([entity4, entity1, entity3, entity2]);
+      expect(result[0].customProperty).to.equal(entity4.customProperty);
+      expect(result[1].customProperty).to.equal(entity2.customProperty);
+      expect(result[2].customProperty).to.equal(entity3.customProperty);
+      expect(result[3].customProperty).to.equal(entity1.customProperty);
     });
   });
 


### PR DESCRIPTION
#### Description
Put docs with the sort field set to `null` at the beginning of the sorted array.

#### Tests
- Added test that checks that fields with a `null` value are sorted to the beginning of the list.
