### PR TITLE
Data stores redesign - fix push() behaviour

### DIFF
--- a/packages/kinvey-html5-sdk/test/config.js
+++ b/packages/kinvey-html5-sdk/test/config.js
@@ -1,5 +1,6 @@
 externalConfig = {
-    appKey: 'kid_H1fs4gFsZ',
-    appSecret: 'aa42a6d47d0049129c985bfb37821877',
-    collectionName: 'Books' 
+  appKey: 'kid_H1fs4gFsZ',
+  appSecret: 'aa42a6d47d0049129c985bfb37821877',
+  collectionWithPreSaveHook: 'WithPreSaveHook',
+  collectionName: 'Books'
 };

--- a/src/core/datastore/sync.spec.js
+++ b/src/core/datastore/sync.spec.js
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import expect from 'expect';
 import chai from 'chai';
+import cloneDeep from 'lodash/cloneDeep';
 import { SyncOperation, syncManagerProvider } from './sync';
 import { SyncStore } from './syncstore';
 import { SyncError } from '../errors';
@@ -253,6 +254,12 @@ describe('Sync', () => {
   });
 
   describe('push()', () => {
+    beforeEach(() => {
+      const store = new SyncStore(collection);
+      return store.clear()
+        .then(() => store.clearSync());
+    });
+
     it('should execute pending sync operations', () => {
       const entity1 = { _id: randomString() };
       const entity2 = { _id: randomString() };
@@ -260,6 +267,12 @@ describe('Sync', () => {
       const entity3Id = randomString();
       const manager = syncManagerProvider.getSyncManager();
       const store = new SyncStore(collection);
+
+      const simulatePreSaveBLHook = (entity) => {
+        const clone = cloneDeep(entity);
+        clone.someNewProperty = true;
+        return clone;
+      };
 
       return store.save(entity1)
         .then(() => store.save(entity2))
@@ -271,31 +284,34 @@ describe('Sync', () => {
         .then(() => {
           nock(client.apiHostname)
             .put(`${backendPathname}/${entity1._id}`, () => true)
-            .query(true)
-            .reply(200, entity1);
+            .reply(200, () => simulatePreSaveBLHook(entity1));
 
           nock(client.apiHostname)
             .delete(`${backendPathname}/${entity2._id}`, () => true)
-            .query(true)
             .reply(200, { count: 1 });
 
           nock(client.apiHostname)
             .post(backendPathname, () => true)
-            .query(true)
-            .reply(200, { _id: entity3Id });
+            .reply(200, simulatePreSaveBLHook({ _id: entity3Id }));
 
           return manager.push(collection);
         })
         .then((result) => {
           expect(result).toEqual([
             { _id: entity2._id, operation: SyncOperation.Delete },
-            { _id: entity1._id, operation: SyncOperation.Update, entity: entity1 },
-            { _id: entity3._id, operation: SyncOperation.Create, entity: { _id: entity3Id } }
+            { _id: entity1._id, operation: SyncOperation.Update, entity: simulatePreSaveBLHook(entity1) },
+            { _id: entity3._id, operation: SyncOperation.Create, entity: simulatePreSaveBLHook({ _id: entity3Id }) }
           ]);
           return manager.getSyncItemCount(collection);
         })
         .then((count) => {
           expect(count).toEqual(0);
+          return store.find().toPromise();
+        })
+        .then((offlineEntities) => {
+          offlineEntities.forEach((entity) => {
+            expect(entity.someNewProperty).toBe(true);
+          });
         });
     });
 

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -149,6 +149,16 @@ export class SyncManager {
     return copy;
   }
 
+  _replaceOfflineEntityWithNetwork(collection, offlineEntityId, networkEntity) {
+    let offlineRepo;
+    return this._getOfflineRepo()
+      .then((repo) => {
+        offlineRepo = repo;
+        return offlineRepo.deleteById(collection, offlineEntityId);
+      })
+      .then(() => offlineRepo.create(collection, networkEntity));
+  }
+
   _pushCreate(collection, entity) {
     let entityToCreate = entity;
     if (entity._kmd && entity._kmd.local) {
@@ -158,8 +168,9 @@ export class SyncManager {
     return this._networkRepo.create(collection, entityToCreate)
       .then((createdItem) => {
         result.entity = createdItem;
-        return result;
+        return this._replaceOfflineEntityWithNetwork(collection, entity._id, createdItem);
       })
+      .then(() => result)
       .catch((err) => {
         result.error = err;
         return result;
@@ -181,8 +192,10 @@ export class SyncManager {
     return this._networkRepo.update(collection, entity)
       .then((updateResult) => {
         result.entity = updateResult;
-        return result;
+        return this._getOfflineRepo();
       })
+      .then(repo => repo.update(collection, result.entity))
+      .then(() => result)
       .catch((err) => {
         result.entity = entity;
         result.error = err;
@@ -190,11 +203,34 @@ export class SyncManager {
       });
   }
 
-  // TODO: refactor results of individual push ops can be done here?
-  _pushItem({ collection, entityId, state }) {
-    let entity;
+  _handlePushOp(syncItem, offlineEntity) {
+    const { collection, state, entityId } = syncItem;
     const syncOp = state.operation;
 
+    if (!offlineEntity && syncOp !== SyncOperation.Delete) { // todo: duplication
+      const res = this._getPushOpResult(entityId, syncOp);
+      res.error = new KinveyError(`Entity with id ${entityId} not found`);
+      return res;
+    }
+
+    switch (syncOp) {
+      case SyncOperation.Create:
+        return this._pushCreate(collection, offlineEntity);
+      case SyncOperation.Delete:
+        return this._pushDelete(collection, entityId);
+      case SyncOperation.Update:
+        return this._pushUpdate(collection, offlineEntity);
+      default: {
+        const res = this._getPushOpResult(entityId, syncOp);
+        res.error = new KinveyError(`Unexpected sync operation: ${syncOp}`);
+        return res;
+      }
+    }
+  }
+
+  // TODO: refactor results of individual push ops can be done here?
+  _pushItem(syncItem) {
+    const { collection, entityId } = syncItem;
     return this._getOfflineRepo()
       .then(repo => repo.readById(collection, entityId))
       .catch((err) => {
@@ -203,29 +239,7 @@ export class SyncManager {
         }
         return Promise.reject(err);
       })
-      .then((offlineEntity) => {
-        entity = offlineEntity;
-
-        if (!entity && syncOp !== SyncOperation.Delete) { // todo: duplication
-          const res = this._getPushOpResult(entityId, syncOp);
-          res.error = new KinveyError(`Entity with id ${entityId} not found`);
-          return res;
-        }
-
-        switch (syncOp) {
-          case SyncOperation.Create:
-            return this._pushCreate(collection, entity);
-          case SyncOperation.Delete:
-            return this._pushDelete(collection, entityId);
-          case SyncOperation.Update:
-            return this._pushUpdate(collection, entity);
-          default: {
-            const res = this._getPushOpResult(entityId, syncOp);
-            res.error = new KinveyError(`Unexpected sync operation: ${syncOp}`);
-            return res;
-          }
-        }
-      });
+      .then(offlineEntity => this._handlePushOp(syncItem, offlineEntity));
   }
 
   _processSyncItem(syncItem) {

--- a/src/core/utils/misc.js
+++ b/src/core/utils/misc.js
@@ -1,4 +1,6 @@
+import { Promise } from 'es6-promise';
 import { Observable } from 'rxjs/Observable';
+import isEmpty from 'lodash/isEmpty';
 
 import { repositoryProvider } from '../datastore';
 
@@ -28,4 +30,27 @@ export function isValidStorageTypeValue(value) {
   const supportedPersistances = repositoryProvider.getSupportedStorages();
   value = ensureArray(value);
   return value.length && value.every(type => supportedPersistances.some(v => type === v));
+}
+
+export function forEachAsync(array, func) {
+  let completed = 0;
+  const totalCount = array.length;
+  if (isEmpty(array)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const onAsyncOpDone = () => {
+      completed += 1;
+      if (completed === totalCount) {
+        resolve();
+      }
+    };
+
+    array.forEach((element) => {
+      func(element)
+        .then(onAsyncOpDone)
+        .catch(onAsyncOpDone);
+    });
+  });
 }

--- a/test/integration/sync.test.js
+++ b/test/integration/sync.test.js
@@ -6,7 +6,18 @@ function testFunc() {
   let cacheStore;
   let storeToTest;
   const notFoundErrorName = 'NotFoundError';
-  const collectionName = externalConfig.collectionName;
+  const collectionName = externalConfig.collectionWithPreSaveHook;
+  const propertyFromBLName = externalConfig.propertyFromBLName || 'propertyFromBL';
+
+  const simulateBLPreSaveHook = (entities) => {
+    const isSingle = !_.isArray(entities);
+    entities = utilities.ensureArray(entities);
+    const clonedEntities = _.cloneDeep(entities);
+    clonedEntities.forEach(e => {
+      e[propertyFromBLName] = true;
+    });
+    return isSingle ? clonedEntities[0] : clonedEntities;
+  };
 
   //validates Push operation result for 1 created, 1 modified and 1 deleted locally items
   const validatePushOperation = (result, createdItem, modifiedItem, deletedItem, expectedServerItemsCount) => {
@@ -17,7 +28,8 @@ function testFunc() {
       if (record.operation !== 'DELETE') {
         utilities.assertEntityMetadata(record.entity);
         utilities.deleteEntityMetadata(record.entity);
-        expect(record.entity).to.deep.equal(record._id === createdItem._id ? createdItem : modifiedItem);
+        const expectedItem = record._id === createdItem._id ? createdItem : modifiedItem;
+        expect(record.entity).to.deep.equal(simulateBLPreSaveHook(expectedItem));
       } else {
         expect(record.entity).to.not.exist;
       }
@@ -39,6 +51,7 @@ function testFunc() {
   //validates Pull operation result
   const validatePullOperation = (result, expectedItems, expectedPulledItemsCount) => {
     expect(result.length).to.equal(expectedPulledItemsCount || expectedItems.length);
+    expectedItems = simulateBLPreSaveHook(expectedItems);
     expectedItems.forEach((entity) => {
       const resultEntity = _.find(result, e => e._id === entity._id);
       expect(utilities.deleteEntityMetadata(resultEntity)).to.deep.equal(entity);
@@ -51,7 +64,7 @@ function testFunc() {
           expect(utilities.deleteEntityMetadata(cachedEntity)).to.deep.equal(entity);
         })
       });
-  }
+  };
 
   dataStoreTypes.forEach((currentDataStoreType) => {
     describe(`${currentDataStoreType} Sync Tests`, () => {
@@ -151,7 +164,7 @@ function testFunc() {
             .then((entities) => {
               expect(entities.length).to.equal(2);
               entities.forEach((entity) => {
-                expect(entity.collection).to.equal(externalConfig.collectionName);
+                expect(entity.collection).to.equal(collectionName);
                 expect(entity.state.operation).to.equal('PUT');
                 expect([entity1._id, entity2._id]).to.include(entity.entityId);
               })
@@ -240,6 +253,22 @@ function testFunc() {
               }).catch(done);
           });
 
+          it('should update local entities with result from network', (done) => {
+            storeToTest.push()
+              .then(() => syncStore.find().toPromise())
+              .then((offlineEntities) => {
+                expect(offlineEntities.length).to.equal(3);
+                const ent1 = offlineEntities.find(e => e._id === entity1._id);
+                const ent2 = offlineEntities.find(e => e._id === entity2._id);
+                const modifiedEntities = offlineEntities.filter(e => propertyFromBLName in e);
+                expect(modifiedEntities.length).to.equal(3);
+                expect(ent1[propertyFromBLName]).to.equal(true);
+                expect(ent2[propertyFromBLName]).to.equal(true);
+              })
+              .then(done)
+              .catch(done);
+          });
+
           it('should log an error, finish the push and not clear the sync queue if an item push fails', (done) => {
             networkStore.removeById(entity3._id)
               .then(() => {
@@ -280,7 +309,7 @@ function testFunc() {
           it('should save the entities from the backend in the cache', (done) => {
             storeToTest.pull()
               .then((result) => {
-                return validatePullOperation(result, [entity1, entity2])
+                return validatePullOperation(result, [entity1, entity2]);
               })
               .then(() => done())
               .catch(done);


### PR DESCRIPTION
#### Description
MLIBZ-2310. Update local entities after doing a `.push()`, to ensure any BL changes to the entities are reflected locally, for create and update pushes. And for backwards compatibility.

#### Changes
Add the logic for updating local entities with the responses to create and update network requests (the current server items). Refactor `SyncManager` to improve readability.
