### PR TITLE
MLIBZ-2162: Allow multiple independent datastores on a single collection

### DIFF
--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -73,7 +73,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -124,7 +125,8 @@ export class CacheStore extends NetworkStore {
                   }),
                   properties: options.properties,
                   body: networkEntities,
-                  timeout: options.timeout
+                  timeout: options.timeout,
+                  tag: this.tag
                 });
                 return request.execute()
                   .then(response => response.data);
@@ -174,7 +176,8 @@ export class CacheStore extends NetworkStore {
           pathname: `${this.pathname}/${id}`
         }),
         properties: options.properties,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
       return request.execute()
         .then(response => response.data)
@@ -215,7 +218,8 @@ export class CacheStore extends NetworkStore {
                   }),
                   properties: options.properties,
                   body: networkEntity,
-                  timeout: options.timeout
+                  timeout: options.timeout,
+                  tag: this.tag
                 });
                 return request.execute()
                   .then(response => response.data);
@@ -261,7 +265,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         aggregation: aggregation,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -335,7 +340,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -412,7 +418,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         body: entity,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -489,7 +496,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         body: entity,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -554,7 +562,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -612,7 +621,8 @@ export class CacheStore extends NetworkStore {
                 }),
                 properties: options.properties,
                 authType: AuthType.Default,
-                timeout: options.timeout
+                timeout: options.timeout,
+                tag: this.tag
               });
               return request.execute()
                 .then(response => response.data);
@@ -663,7 +673,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         authType: AuthType.Default,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -717,7 +728,8 @@ export class CacheStore extends NetworkStore {
             }),
             properties: options.properties,
             authType: AuthType.Default,
-            timeout: options.timeout
+            timeout: options.timeout,
+            tag: this.tag
           });
           return request.execute()
             .then(response => response.data);
@@ -756,7 +768,8 @@ export class CacheStore extends NetworkStore {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -790,7 +803,8 @@ export class CacheStore extends NetworkStore {
                   }),
                   properties: options.properties,
                   authType: AuthType.Default,
-                  timeout: options.timeout
+                  timeout: options.timeout,
+                  tag: this.tag
                 });
                 return request.execute()
                   .then(response => response.data);
@@ -875,7 +889,8 @@ export class CacheStore extends NetworkStore {
               }),
               properties: options.properties,
               body: entities,
-              timeout: options.timeout
+              timeout: options.timeout,
+              tag: this.tag
             });
             return saveRequest.execute();
           })

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -28,12 +28,12 @@ export class NetworkStore {
       let tag = options.tag;
 
       if (!isString(tag)) {
-        throw new KinveyError('options.tag must be a string.');
+        throw new KinveyError('A tag must be a string.');
       }
 
       tag = tag.trimRight();
-      if (/^[a-zA-Z0-9-]+$/.test(tag)) {
-        throw new KinveyError('options.tag can only contain letters, numbers, and "-".');
+      if (!/^[a-zA-Z0-9-]+$/.test(tag)) {
+        throw new KinveyError('A tag can only contain letters, numbers, and "-".');
       }
 
       this.tag = tag;

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -25,6 +25,11 @@ export class NetworkStore {
     this.collection = collection;
 
     /**
+     * @type {string}
+     */
+    this.tag = options.tag || undefined;
+
+    /**
      * @type {Client}
      */
     this.client = options.client;
@@ -107,7 +112,8 @@ export class NetworkStore {
         properties: options.properties,
         query: query,
         timeout: options.timeout,
-        client: this.client
+        client: this.client,
+        tag: this.tag
       };
       let request = new KinveyRequest(config);
 
@@ -156,7 +162,8 @@ export class NetworkStore {
         }),
         properties: options.properties,
         timeout: options.timeout,
-        client: this.client
+        client: this.client,
+        tag: this.tag
       };
       let request = new KinveyRequest(config);
 

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -32,8 +32,8 @@ export class NetworkStore {
       }
 
       tag = tag.trimRight();
-      if (tag === '') {
-        throw new KinveyError('options.tag cannot be an empty string.');
+      if (/^[a-zA-Z0-9-]+$/.test(tag)) {
+        throw new KinveyError('options.tag can only contain letters, numbers, and "-".');
       }
 
       this.tag = tag;

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -24,6 +24,10 @@ export class NetworkStore {
      */
     this.collection = collection;
 
+    if (options.tag && !isString(options.tag)) {
+      throw new KinveyError('options.tag must be a string.');
+    }
+
     /**
      * @type {string}
      */

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -24,14 +24,20 @@ export class NetworkStore {
      */
     this.collection = collection;
 
-    if (options.tag && !isString(options.tag)) {
-      throw new KinveyError('options.tag must be a string.');
-    }
+    if (options.tag) {
+      let tag = options.tag;
 
-    /**
-     * @type {string}
-     */
-    this.tag = options.tag || undefined;
+      if (!isString(tag)) {
+        throw new KinveyError('options.tag must be a string.');
+      }
+
+      tag = tag.trimRight();
+      if (tag === '') {
+        throw new KinveyError('options.tag cannot be an empty string.');
+      }
+
+      this.tag = tag;
+    }
 
     /**
      * @type {Client}

--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -31,7 +31,6 @@ export class NetworkStore {
         throw new KinveyError('A tag must be a string.');
       }
 
-      tag = tag.trimRight();
       if (!/^[a-zA-Z0-9-]+$/.test(tag)) {
         throw new KinveyError('A tag can only contain letters, numbers, and "-".');
       }

--- a/src/core/datastore/sync.js
+++ b/src/core/datastore/sync.js
@@ -108,7 +108,8 @@ export class SyncManager {
           properties: options.properties,
           query: syncQuery,
           timeout: options.timeout,
-          client: this.client
+          client: this.client,
+          tag: this.tag
         });
         return request.execute()
           .then(response => response.data);
@@ -178,7 +179,8 @@ export class SyncManager {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
       return findRequest.execute()
         .then(response => response.data)
@@ -201,7 +203,8 @@ export class SyncManager {
             }),
             properties: options.properties,
             body: syncEntity,
-            timeout: options.timeout
+            timeout: options.timeout,
+            tag: this.tag
           });
           return request.execute();
         });
@@ -330,7 +333,8 @@ export class SyncManager {
                           pathname: `${this.pathname}/${syncEntity._id}`
                         }),
                         properties: options.properties,
-                        timeout: options.timeout
+                        timeout: options.timeout,
+                        tag: this.tag
                       });
                       return request.execute();
                     })
@@ -378,8 +382,7 @@ export class SyncManager {
                         properties: options.properties,
                         timeout: options.timeout,
                         body: entity,
-                        client: this.client,
-                        tag: this.tag
+                        client: this.client
                       });
 
                       // Send a POST request, and update the url.
@@ -410,7 +413,8 @@ export class SyncManager {
                               pathname: `${this.pathname}/${syncEntity._id}`
                             }),
                             properties: options.properties,
-                            timeout: options.timeout
+                            timeout: options.timeout,
+                            tag: this.tag
                           });
                           return request.execute()
                             .then(() => {
@@ -548,7 +552,8 @@ export class SyncManager {
               pathname: `${this.pathname}/${entity._id}`
             }),
             properties: options.properties,
-            timeout: options.timeout
+            timeout: options.timeout,
+            tag: this.tag
           });
           return request.execute()
             .then(response => response.data);

--- a/src/core/datastore/sync.js
+++ b/src/core/datastore/sync.js
@@ -85,7 +85,8 @@ export class SyncManager {
       query: query,
       properties: options.properties,
       timeout: options.timeout,
-      client: this.client
+      client: this.client,
+      tag: this.tag
     });
     return request.execute()
       .then(response => response.data)

--- a/src/core/datastore/sync.js
+++ b/src/core/datastore/sync.js
@@ -42,6 +42,11 @@ export class SyncManager {
     this.collection = collection;
 
     /**
+     * @type {string}
+     */
+    this.tag = options.tag || undefined;
+
+    /**
      * @type {Client}
      */
     this.client = options.client || Client.sharedInstance();
@@ -244,7 +249,8 @@ export class SyncManager {
           properties: options.properties,
           query: query,
           timeout: options.timeout,
-          client: this.client
+          client: this.client,
+          tag: this.tag
         };
         let request = new KinveyRequest(config);
 
@@ -309,7 +315,8 @@ export class SyncManager {
                     }),
                     properties: options.properties,
                     timeout: options.timeout,
-                    client: this.client
+                    client: this.client,
+                    tag: this.tag
                   });
                   return request.execute()
                     .then(() => {
@@ -352,7 +359,8 @@ export class SyncManager {
                       pathname: `${this.backendPathname}/${entityId}`
                     }),
                     properties: options.properties,
-                    timeout: options.timeout
+                    timeout: options.timeout,
+                    tag: this.tag
                   });
                   return request.execute()
                     .then(response => response.data)
@@ -369,7 +377,8 @@ export class SyncManager {
                         properties: options.properties,
                         timeout: options.timeout,
                         body: entity,
-                        client: this.client
+                        client: this.client,
+                        tag: this.tag
                       });
 
                       // Send a POST request, and update the url.
@@ -414,7 +423,8 @@ export class SyncManager {
                                 }),
                                 properties: options.properties,
                                 timeout: options.timeout,
-                                body: entity
+                                body: entity,
+                                tag: this.tag
                               });
                               return request.execute()
                                 .then(response => response.data);
@@ -430,7 +440,8 @@ export class SyncManager {
                                     pathname: `${this.backendPathname}/${entityId}`
                                   }),
                                   properties: options.properties,
-                                  timeout: options.timeout
+                                  timeout: options.timeout,
+                                  tag: this.tag
                                 });
 
                                 return request.execute()

--- a/src/core/datastore/sync.spec.js
+++ b/src/core/datastore/sync.spec.js
@@ -56,6 +56,30 @@ describe('Sync', () => {
     return sync.clear();
   });
 
+  describe('find()', () => {
+    const entity1 = { _id: randomString() };
+    const entity2 = { _id: randomString() };
+
+    beforeEach(() => {
+      const store = new SyncStore(collection, { tag: 'entity1' });
+      return store.save(entity1);
+    });
+
+    beforeEach(() => {
+      const store = new SyncStore(collection, { tag: 'entity2' });
+      return store.save(entity2);
+    });
+
+    it('should return the entities by tag', () => {
+      const sync = new SyncManager(collection, { tag: 'entity1' });
+      return sync.find()
+        .then((entities) => {
+          expect(entities.length).toEqual(1);
+          expect(entities[0].entityId).toEqual(entity1._id);
+        });
+    });
+  });
+
   describe('count()', () => {
     const entity1 = { _id: randomString() };
     const entity2 = { _id: randomString() };

--- a/src/core/datastore/syncstore.js
+++ b/src/core/datastore/syncstore.js
@@ -47,7 +47,8 @@ export class SyncStore extends CacheStore {
         }),
         properties: options.properties,
         query: query,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -89,7 +90,8 @@ export class SyncStore extends CacheStore {
             pathname: `${this.pathname}/${id}`
           }),
           properties: options.properties,
-          timeout: options.timeout
+          timeout: options.timeout,
+          tag: this.tag
         });
 
         return request.execute()
@@ -132,7 +134,8 @@ export class SyncStore extends CacheStore {
         }),
         properties: options.properties,
         aggregation: aggregation,
-        timeout: options.timeout
+        timeout: options.timeout,
+        tag: this.tag
       });
 
       // Execute the request
@@ -175,7 +178,8 @@ export class SyncStore extends CacheStore {
           }),
           properties: options.properties,
           query: query,
-          timeout: options.timeout
+          timeout: options.timeout,
+          tag: this.tag
         });
 
         return request.execute()

--- a/src/core/datastore/syncstore.spec.js
+++ b/src/core/datastore/syncstore.spec.js
@@ -143,30 +143,26 @@ describe('SyncStore', () => {
     it('should return the entities by tag', () => {
       const entity1 = { _id: randomString() };
       const entity2 = { _id: randomString() };
+      const store1 = new SyncStore(collection, { tag: randomString() });
+      const store2 = new SyncStore(collection, { tag: randomString() });
+      const query1 = new Query().equalTo('_id', entity1._id);
+      const query2 = new Query().equalTo('_id', entity2._id);
 
-      const optionsFoo = { tag: randomString() };
-      const storeFoo = new SyncStore(collection, optionsFoo);
-      const queryFoo = new Query().equalTo('_id', entity1._id);
-
-      const optionsBar = { tag: randomString() };
-      const storeBar = new SyncStore(collection, optionsBar);
-      const queryBar = new Query().equalTo('_id', entity2._id);
-
-      nock(storeFoo.client.apiHostname)
-        .get(`/appdata/${storeFoo.client.appKey}/${collection}`)
+      nock(store1.client.apiHostname)
+        .get(`/appdata/${store1.client.appKey}/${collection}`)
         .query({ query: JSON.stringify({ _id: entity1._id }) })
         .reply(200, [entity1]);
 
-      nock(storeBar.client.apiHostname)
-        .get(`/appdata/${storeBar.client.appKey}/${collection}`)
+      nock(store2.client.apiHostname)
+        .get(`/appdata/${store2.client.appKey}/${collection}`)
         .query({ query: JSON.stringify({ _id: entity2._id }) })
         .reply(200, [entity2]);
 
-      return storeFoo.pull(queryFoo)
+      return store1.pull(query1)
         .then(() => {
-          return storeBar.pull(queryBar)
+          return store2.pull(query2)
         }).then(() => {
-          return storeBar.find().toPromise()
+          return store2.find().toPromise()
             .then((result) => {
               expect(result).toEqual([entity2]);
             });

--- a/src/core/datastore/syncstore.spec.js
+++ b/src/core/datastore/syncstore.spec.js
@@ -128,6 +128,18 @@ describe('SyncStore', () => {
         });
     });
 
+    it('should throw an error if the tag is not a string', () => {
+      expect(() => {
+        new SyncStore(collection, { tag: {} });
+      }).toThrow();
+    });
+
+    it('should throw an error if the tag is an emptry string', () => {
+      expect(() => {
+        new SyncStore(collection, { tag: ' ' });
+      }).toThrow();
+    });
+
     it('should return the entities by tag', () => {
       const entity1 = { _id: "123foo" };
       const entity2 = { _id: "123bar" };

--- a/src/core/request/cache.js
+++ b/src/core/request/cache.js
@@ -49,24 +49,16 @@ export class CacheRequest extends Request {
     this._aggregation = aggregation;
   }
 
-  get tag() {
-    return this._tag;
-  }
-
-  set tag(tag) {
-    this._tag = tag;
-  }
-
   get collection() {
+    if (isDefined(this.tag)) {
+      return  this._collection + this.tag;
+    }
+
     return this._collection;
   }
 
   set collection(collection) {
-    if (isDefined(this.tag)) {
-      this._collection = collection + this.tag;
-    } else {
-      this._collection = collection;
-    }
+    this._collection = collection;
   }
 
   get url() {

--- a/src/core/request/cache.js
+++ b/src/core/request/cache.js
@@ -51,7 +51,7 @@ export class CacheRequest extends Request {
 
   get collection() {
     if (isDefined(this.tag)) {
-      return  this._collection + this.tag;
+      return  `${this._collection}.${this.tag}`;
     }
 
     return this._collection;

--- a/src/core/request/cache.js
+++ b/src/core/request/cache.js
@@ -14,6 +14,7 @@ export class CacheRequest extends Request {
     this.aggregation = options.aggregation;
     this.query = options.query;
     this.rack = CacheRack;
+    this.tag = options.tag;
   }
 
   get body() {
@@ -46,6 +47,26 @@ export class CacheRequest extends Request {
     }
 
     this._aggregation = aggregation;
+  }
+
+  get tag() {
+    return this._tag;
+  }
+
+  set tag(tag) {
+    this._tag = tag;
+  }
+
+  get collection() {
+    return this._collection;
+  }
+
+  set collection(collection) {
+    if (isDefined(this.tag)) {
+      this._collection = collection + this.tag;
+    } else {
+      this._collection = collection;
+    }
   }
 
   get url() {

--- a/src/core/request/deltafetch.js
+++ b/src/core/request/deltafetch.js
@@ -17,6 +17,11 @@ import  { Response, StatusCode } from './response';
 const maxIdsPerRequest = 200;
 
 export class DeltaFetchRequest extends KinveyRequest {
+  constructor(options = {}) {
+    super(options);
+    this.tag = options.tag;
+  }
+
   get method() {
     return super.method;
   }
@@ -51,7 +56,8 @@ export class DeltaFetchRequest extends KinveyRequest {
       headers: this.headers,
       query: this.query,
       timeout: this.timeout,
-      client: this.client
+      client: this.client,
+      tag: this.tag
     });
     return request.execute()
       .then(response => response.data)


### PR DESCRIPTION
#### Changes
- Added `options.tag` to `Kinvey.DataStore.collection()`. This allows a datastore to interact with a subset of entities in the cache for a collection without providing a query each time.

```javascript
const datastore = Kinvey.DataStore.collection('books', Kinvey.DataStoreType.Cache, { tag: 'Kinvey' });
datastore.find(); // This will find all the books tagged as 'Kinvey' on the books collection
```

#### Tests
- Added a unit test that uses `datastore.pull()` to verify that only a subset of entities are returned for a collection when using a tag