### PR TITLE
MLIBZ-2031: Cache not returning same items as backend after sync

### DIFF
--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -862,23 +862,19 @@ export class CacheStore extends NetworkStore {
     options = assign({ useDeltaFetch: this.useDeltaFetch }, options);
     return this.syncManager.pull(query, options)
       .then((entities) => {
-        // Clear the cache
-        return this.clear(query, options)
-          .then(() => {
-            // Save network entities to cache
-            const saveRequest = new CacheRequest({
-              method: RequestMethod.PUT,
-              url: url.format({
-                protocol: this.client.apiProtocol,
-                host: this.client.apiHost,
-                pathname: this.pathname
-              }),
-              properties: options.properties,
-              body: entities,
-              timeout: options.timeout
-            });
-            return saveRequest.execute();
-          })
+        // Save network entities to cache
+        const saveRequest = new CacheRequest({
+          method: RequestMethod.PUT,
+          url: url.format({
+            protocol: this.client.apiProtocol,
+            host: this.client.apiHost,
+            pathname: this.pathname
+          }),
+          properties: options.properties,
+          body: entities,
+          timeout: options.timeout
+        });
+        return saveRequest.execute()
           .then(() => entities);
       });
   }

--- a/src/core/datastore/syncstore.spec.js
+++ b/src/core/datastore/syncstore.spec.js
@@ -756,6 +756,42 @@ describe('SyncStore', () => {
           expect(entities).toEqual([entity1, entity2]);
         });
     });
+
+    it('should save the entities from the backend to the cache from multiple pulls', () => {
+      const store = new SyncStore(collection);
+
+      return store.clear()
+        .then(() => {
+          const promises = [];
+
+          for (let i = 0; i < 2; i++) {
+            const doc = { _id: randomString() };
+            const query = new Query();
+            query.limit = 1;
+            query.skip = i;
+
+            nock(store.client.apiHostname)
+              .get(`/appdata/${store.client.appKey}/${collection}`)
+              .query(query.toQueryString())
+              .reply(200, [doc]);
+
+            promises.push(store.pull(query));
+          }
+
+          return Promise.all(promises);
+        })
+        .then((results) => {
+          return results.reduce((docs, result) => {
+            return docs.concat(result);
+          }, []);
+        })
+        .then((docs) => {
+          return store.find().toPromise()
+          .then((cachedDocs) => {
+            expect(cachedDocs).toEqual(docs);
+          });
+        });
+    });
   });
 
   describe('sync', () => {

--- a/src/core/datastore/syncstore.spec.js
+++ b/src/core/datastore/syncstore.spec.js
@@ -53,9 +53,7 @@ describe('SyncStore', () => {
   afterEach(() => {
     const store = new SyncStore(collection);
     return store.clear()
-      .then(() => {
-        return store.clearSync();
-      });
+      .then(() => store.clearSync());
   });
 
   describe('pathname', () => {
@@ -619,6 +617,7 @@ describe('SyncStore', () => {
         })
         .then((entities) => {
           expect(entities).toEqual([]);
+          return store.clear();
         });
     });
 

--- a/src/html5/storage/webstorage/localstorage.js
+++ b/src/html5/storage/webstorage/localstorage.js
@@ -7,8 +7,13 @@ const MASTER_COLLECTION = '__master__';
 class LocalStorage extends WebStorage {
   find(collection) {
     try {
-      const entities = JSON.parse(global.localStorage.getItem(`${this.name}.${collection}`));
-      return Promise.resolve(entities || []);
+      const entities = global.localStorage.getItem(`${this.name}.${collection}`);
+
+      if (entities) {
+        return Promise.resolve(JSON.parse(entities));
+      }
+
+      return Promise.resolve([]);
     } catch (error) {
       return Promise.reject(error);
     }

--- a/src/html5/storage/webstorage/localstorage.spec.js
+++ b/src/html5/storage/webstorage/localstorage.spec.js
@@ -1,0 +1,83 @@
+import Promise from 'es6-promise';
+import { expect, use } from 'chai';
+import { stub } from 'sinon';
+import { LocalStorageAdapter } from './localstorage';
+
+const localStorageStore = {};
+const localStorage = {
+  getItem(key) {
+    return localStorageStore[key];
+  },
+
+  setItem(key, value) {
+    localStorageStore[key] = value;
+  },
+
+  removeItem(key) {
+    delete localStorageStore[key];
+  }
+};
+
+describe('LocalStorage', () => {
+  let adapter;
+
+  before(() => {
+    global.localStorage = localStorage;
+  });
+
+  before(() => {
+    return LocalStorageAdapter.load('test')
+      .then((localStorageAdapter) => {
+        adapter = localStorageAdapter;
+      });
+  });
+
+  after(() => {
+    delete global.localStorage;
+  });
+
+  afterEach(() => adapter.clear());
+
+  describe('find()', () => {
+    let docs = [];
+
+    beforeEach(() => {
+      for (let i = 0; i < 10; i++) {
+        docs.push({ _id: i });
+      }
+
+      return adapter.save('docs', docs);
+    });
+
+    it('should return all the docs', () => {
+      return adapter.find('docs')
+        .then((savedDocs) => {
+          expect(savedDocs).to.deep.equal(docs);
+        });
+    });
+  });
+
+  describe('save()', () => {
+    it('should save the doc', () => {
+      const doc = { _id: 0 };
+
+      return adapter.save('docs', doc)
+        .then((savedDoc) => {
+          expect(savedDoc).to.deep.equal(doc);
+        });
+    });
+
+    it('should save the docs', () => {
+      const docs = [];
+
+      for (let i = 0; i < 10; i++) {
+        docs.push({ _id: i });
+      }
+
+      return adapter.save('docs', docs)
+        .then((savedDocs) => {
+          expect(savedDocs).to.deep.equal(docs);
+        });
+    });
+  });
+});

--- a/src/html5/storage/webstorage/sessionstorage.js
+++ b/src/html5/storage/webstorage/sessionstorage.js
@@ -6,8 +6,13 @@ const MASTER_COLLECTION = '__master__';
 class SessionStorage extends WebStorage {
   find(collection) {
     try {
-      const entities = JSON.parse(global.sessionStorage.getItem(`${this.name}.${collection}`));
-      return Promise.resolve(entities || []);
+      const entities = global.sessionStorage.getItem(`${this.name}.${collection}`);
+
+      if (entities) {
+        return Promise.resolve(JSON.parse(entities));
+      }
+
+      return Promise.resolve([]);
     } catch (error) {
       return Promise.reject(error);
     }

--- a/src/html5/storage/webstorage/sessionstorage.spec.js
+++ b/src/html5/storage/webstorage/sessionstorage.spec.js
@@ -1,0 +1,83 @@
+import Promise from 'es6-promise';
+import { expect, use } from 'chai';
+import { stub } from 'sinon';
+import { SessionStorageAdapter } from './sessionstorage';
+
+const store = {};
+const sessionStorage = {
+  getItem(key) {
+    return store[key];
+  },
+
+  setItem(key, value) {
+    store[key] = value;
+  },
+
+  removeItem(key) {
+    delete store[key];
+  }
+};
+
+describe('SessionStorage', () => {
+  let adapter;
+
+  before(() => {
+    global.sessionStorage = sessionStorage;
+  });
+
+  before(() => {
+    return SessionStorageAdapter.load('test')
+      .then((sessionStorageAdapter) => {
+        adapter = sessionStorageAdapter;
+      });
+  });
+
+  after(() => {
+    delete global.sessionStorage;
+  });
+
+  afterEach(() => adapter.clear());
+
+  describe('find()', () => {
+    let docs = [];
+
+    beforeEach(() => {
+      for (let i = 0; i < 10; i++) {
+        docs.push({ _id: i });
+      }
+
+      return adapter.save('docs', docs);
+    });
+
+    it('should return all the docs', () => {
+      return adapter.find('docs')
+        .then((savedDocs) => {
+          expect(savedDocs).to.deep.equal(docs);
+        });
+    });
+  });
+
+  describe('save()', () => {
+    it('should save the doc', () => {
+      const doc = { _id: 0 };
+
+      return adapter.save('docs', doc)
+        .then((savedDoc) => {
+          expect(savedDoc).to.deep.equal(doc);
+        });
+    });
+
+    it('should save the docs', () => {
+      const docs = [];
+
+      for (let i = 0; i < 10; i++) {
+        docs.push({ _id: i });
+      }
+
+      return adapter.save('docs', docs)
+        .then((savedDocs) => {
+          expect(savedDocs).to.deep.equal(docs);
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### Changes
- Do not clear the cache when performing a `pull()`.

#### Tests
- Added a unit test that uses multiple pulls and validates the cache.