### PR TITLE
Add test for sync suite

### DIFF
--- a/test/integration/configs/tests-config.js
+++ b/test/integration/configs/tests-config.js
@@ -1,6 +1,9 @@
 
 const testsConfig = {
-  collectionName: 'Books'
+  collectionName: 'Books',
+  collectionWithPreSaveHook: 'WithPreSaveHook',
+  propertyFromBLName: 'propertyFromBL',
+  propertyFromBLValue: true
 };
 
 const appCredentials = {
@@ -28,7 +31,7 @@ const appCredentials = {
       appSecret: 'c00090630ace4eb3956367a44319afcf',
     }
   }
-}
+};
 
 module.exports = {
   testsConfig: testsConfig,

--- a/test/integration/create-platform-specific-config.js
+++ b/test/integration/create-platform-specific-config.js
@@ -21,16 +21,15 @@ const createPlatformSpecificConfig = (platform, os) => {
       appKey: app.appKey,
       appSecret: app.appSecret
     };
-  }
+  };
 
   const credentialsToUse = getCredentialsByEnvironment(appCredentials, platform, os);
   Object.assign(testsConfig, credentialsToUse);
 
   const crossPlatformExport = fs.readFileSync(configTemplateFilePath, 'utf8');
-  const compiled = lodash.template(crossPlatformExport)
-  const configFileContents = compiled({ 'appConfig': JSON.stringify(testsConfig, null, 2) })
+  const compiled = lodash.template(crossPlatformExport);
+  const configFileContents = compiled({ appConfig: JSON.stringify(testsConfig, null, 2) });
   fs.writeFileSync(resultConfigFilePath, configFileContents, 'utf8');
-}
+};
 
 module.exports = createPlatformSpecificConfig;
-


### PR DESCRIPTION
Add test to sync suite, to check if changes from BL are reflected offline.

@tsvetomir-nedyalkov This shouldn't be merged before the new collection is created with the proper (same as the old collection's) permissions set. And a PreSave cloud code hook is added for the new collection, setting the property from the config, to the expected value (also in the config).
