### PR TITLE
Integration tests additions

### DIFF
--- a/packages/kinvey-html5-sdk/test/tasks/serveTests.js
+++ b/packages/kinvey-html5-sdk/test/tasks/serveTests.js
@@ -4,21 +4,21 @@ const finalhandler = require('finalhandler');
 const serveStatic = require('serve-static');
 
 const serveTests = (appRoot, runner) =>
-    new Promise(resolve => {
-        const serve = serveStatic(appRoot);
+  new Promise(resolve => {
+    const serve = serveStatic(appRoot);
 
-        const server = http.createServer(function(req, res) {
-            const done = finalhandler(req, res);
-            serve(req, res, done);
-        });
-
-        server.listen(0, () => {
-            const staticPort = server.address().port;
-            runner.emit('serve.static', staticPort);
-            console.log(`Serving static files on port: ${staticPort}`);
-
-            return resolve(staticPort);
-        });
+    const server = http.createServer((req, res) => {
+      const done = finalhandler(req, res);
+      serve(req, res, done);
     });
+
+    server.listen(0, () => {
+      const staticPort = server.address().port;
+      runner.emit('serve.static', staticPort);
+      console.log(`Serving static files on port: ${staticPort}`);
+
+      return resolve(staticPort);
+    });
+  });
 
 module.exports = appRoot => ['serveTests', serveTests, appRoot];

--- a/packages/kinvey-html5-sdk/test/tasks/webRunTests.js
+++ b/packages/kinvey-html5-sdk/test/tasks/webRunTests.js
@@ -1,23 +1,22 @@
 const os = require('os');
 const spawnHeadlessChromium = require('run-headless-chromium').spawn;
 const opn = require('opn');
-const path = require('path');
 
 const webRunTests = (staticPort, runner) =>
-    new Promise((resolve, reject) => {
-        const args = [`http://localhost:${staticPort()}/packages/kinvey-html5-sdk/test/index.html`];
+  new Promise((resolve, reject) => {
+    const args = [`http://localhost:${staticPort()}/packages/kinvey-html5-sdk/test/index.html`];
 
-        if (os.type() === 'Windows_NT') {
-            opn(args[0], {
-                app: ['chrome', '--incognito']
-            })
-                .then(resolve)
-                .catch(reject);
-        } else {
-            const chrome = spawnHeadlessChromium(args);
-            chrome.stderr.on('data', d => reject(d.toString()));
-            resolve();
-        }
-    });
+    if (os.type() === 'Windows_NT') {
+      opn(args[0], {
+        app: ['chrome', '--incognito']
+      })
+        .then(resolve)
+        .catch(reject);
+    } else {
+      const chrome = spawnHeadlessChromium(args);
+      chrome.stderr.on('data', d => reject(d.toString()));
+      resolve();
+    }
+  });
 
 module.exports = staticPort => ['webRunTests', webRunTests, staticPort];

--- a/test/integration/tests/crud-entity/common-crud.test.js
+++ b/test/integration/tests/crud-entity/common-crud.test.js
@@ -153,9 +153,13 @@ function testFunc() {
 
             storeToTest.findById(entityId).subscribe(nextHandlerSpy, (err) => {
               const expectedCallCount = dataStoreType === Kinvey.DataStoreType.Cache ? 1 : 0;
-              expect(nextHandlerSpy.callCount).to.equal(expectedCallCount);
-              expect(err.name).to.contain(notFoundErrorName);
-              done();
+              try {
+                expect(nextHandlerSpy.callCount).to.equal(expectedCallCount);
+                expect(err.name).to.contain(notFoundErrorName);
+              } catch (err) {
+                return done(err);
+              }
+              return done();
             }, () => {
               done(new Error('Should not be called'));
             });
@@ -164,10 +168,14 @@ function testFunc() {
           it('should return undefined if an id is not provided', (done) => {
             const spy = sinon.spy();
             storeToTest.findById().subscribe(spy, done, () => {
-              expect(spy.callCount).to.equal(1);
-              const result = spy.firstCall.args[0];
-              expect(result).to.be.undefined;
-              done();
+              try {
+                expect(spy.callCount).to.equal(1);
+                const result = spy.firstCall.args[0];
+                expect(result).to.be.undefined;
+              } catch (err) {
+                return done(err);
+              }
+              return done();
             });
           });
 

--- a/test/integration/tests/crud-entity/common-crud.test.js
+++ b/test/integration/tests/crud-entity/common-crud.test.js
@@ -149,22 +149,26 @@ function testFunc() {
         describe('findById()', () => {
           it('should throw a NotFoundError if the id argument does not exist', (done) => {
             const entityId = utilities.randomString();
-            storeToTest.findById(entityId).toPromise()
-              .then(() => done(new Error('Should not be called')))
-              .catch((error) => {
-                expect(error.name).to.contain(notFoundErrorName);
-                done();
-              })
-              .catch(done);
+            const nextHandlerSpy = sinon.spy();
+
+            storeToTest.findById(entityId).subscribe(nextHandlerSpy, (err) => {
+              const expectedCallCount = dataStoreType === Kinvey.DataStoreType.Cache ? 1 : 0;
+              expect(nextHandlerSpy.callCount).to.equal(expectedCallCount);
+              expect(err.name).to.contain(notFoundErrorName);
+              done();
+            }, () => {
+              done(new Error('Should not be called'));
+            });
           });
 
           it('should return undefined if an id is not provided', (done) => {
-            storeToTest.findById().toPromise()
-              .then((result) => {
-                expect(result).to.be.undefined;
-                done();
-              })
-              .catch(done);
+            const spy = sinon.spy();
+            storeToTest.findById().subscribe(spy, done, () => {
+              expect(spy.callCount).to.equal(1);
+              const result = spy.firstCall.args[0];
+              expect(result).to.be.undefined;
+              done();
+            });
           });
 
           it('should return the entity that matches the id argument', (done) => {

--- a/test/integration/tests/crud-entity/common-crud.test.js
+++ b/test/integration/tests/crud-entity/common-crud.test.js
@@ -353,8 +353,7 @@ function testFunc() {
               });
           });
 
-          // should be added back for execution when MLIBZ-2157 is fixed
-          it.skip('query.notEqualTo with null', (done) => {
+          it('query.notEqualTo with null', (done) => {
             query.notEqualTo(textFieldName, null);
             const expectedEntities = entities.filter(entity => entity[textFieldName] !== null);
             storeToTest.find(query)

--- a/test/integration/tests/crud-entity/offline-crud.test.js
+++ b/test/integration/tests/crud-entity/offline-crud.test.js
@@ -71,10 +71,8 @@ function testFunc() {
                 expect(foundEntity).to.exist;
                 return syncStore.findById(entity._id).toPromise();
               })
-              .then(() => {
-                utilities.validateEntity(dataStoreType, collectionName, entity);
-                return cacheStore.removeById(entity._id); // remove the new entity, as it is not used elsewhere
-              })
+              .then(() => utilities.validateEntity(dataStoreType, collectionName, entity))
+              .then(() => cacheStore.removeById(entity._id)) // remove the new entity, as it is not used elsewhere
               .then((result) => {
                 expect(result).to.deep.equal({ count: 1 });
                 done();

--- a/test/integration/tests/crud-entity/offline-crud.test.js
+++ b/test/integration/tests/crud-entity/offline-crud.test.js
@@ -73,6 +73,10 @@ function testFunc() {
               })
               .then(() => {
                 utilities.validateEntity(dataStoreType, collectionName, entity);
+                return cacheStore.removeById(entity._id); // remove the new entity, as it is not used elsewhere
+              })
+              .then((result) => {
+                expect(result).to.deep.equal({ count: 1 });
                 done();
               })
               .catch(done);

--- a/test/integration/tests/crud-entity/offline-crud.test.js
+++ b/test/integration/tests/crud-entity/offline-crud.test.js
@@ -63,6 +63,21 @@ function testFunc() {
               .catch(done);
           });
 
+          it('findById() should create in the cache, an entity found on the backend, but missing in the cache', (done) => {
+            const entity = utilities.getEntity(utilities.randomString());
+            networkStore.create(entity)
+              .then(() => storeToTest.findById(entity._id).toPromise())
+              .then((foundEntity) => {
+                expect(foundEntity).to.exist;
+                return syncStore.findById(entity._id).toPromise();
+              })
+              .then(() => {
+                utilities.validateEntity(dataStoreType, collectionName, entity);
+                done();
+              })
+              .catch(done);
+          });
+
           it.skip('findById() should remove entities that no longer exist on the backend from the cache', (done) => {
             const entity = utilities.getEntity(utilities.randomString());
             storeToTest.save(entity)

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -107,76 +107,84 @@ function testFunc() {
             .catch(done);
         });
 
-        it('pendingSyncCount() should return the count of the entities waiting to be synced', (done) => {
-          storeToTest.pendingSyncCount()
-            .then((count) => {
-              expect(count).to.equal(2);
-              done();
-            }).catch(done);
+        describe('pendingSyncCount()', () => {
+          it('should return the count of the entities waiting to be synced', (done) => {
+            storeToTest.pendingSyncCount()
+              .then((count) => {
+                expect(count).to.equal(2);
+                done();
+              })
+              .catch(done);
+          });
+
+          it('should return the count of the entities, matching the query', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity1._id);
+            storeToTest.pendingSyncCount(query)
+              .then((count) => {
+                expect(count).to.equal(1);
+                done();
+              })
+              .catch(done);
+          });
         });
 
-        it('pendingSyncCount() should return the count of the entities, matching the query', (done) => {
-          const query = new Kinvey.Query();
-          query.equalTo('_id', entity1._id);
-          storeToTest.pendingSyncCount(query)
-            .then((count) => {
-              expect(count).to.equal(1);
-              done();
-            }).catch(done);
+        describe('clearSync()', () => {
+          it('should clear the pending sync queue', (done) => {
+            syncStore.clearSync()
+              .then(() => storeToTest.pendingSyncCount())
+              .then((count) => {
+                expect(count).to.equal(0);
+                done();
+              }).catch(done);
+          });
+
+          it('should clear only the items, matching the query from the pending sync queue', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity1._id);
+            syncStore.clearSync(query)
+              .then(() => storeToTest.pendingSyncEntities())
+              .then((result) => {
+                expect(result.length).to.equal(1);
+                expect(result[0].entityId).to.equal(entity2._id);
+                done();
+              }).catch(done);
+          });
         });
 
-        it('clearSync() should clear the pending sync queue', (done) => {
-          syncStore.clearSync()
-            .then(() => storeToTest.pendingSyncCount())
-            .then((count) => {
-              expect(count).to.equal(0);
-              done();
-            }).catch(done);
-        });
+        describe('pendingSyncEntities()', () => {
+          it('should return only the entities waiting to be synced', (done) => {
+            storeToTest.pendingSyncEntities()
+              .then((entities) => {
+                expect(entities.length).to.equal(2);
+                entities.forEach((entity) => {
+                  expect(entity.collection).to.equal(collectionName);
+                  expect(entity.state.operation).to.equal('PUT');
+                  expect([entity1._id, entity2._id]).to.include(entity.entityId);
+                });
+                done();
+              }).catch(done);
+          });
 
-        it('clearSync() should clear only the items, matching the query from the pending sync queue', (done) => {
-          const query = new Kinvey.Query();
-          query.equalTo('_id', entity1._id);
-          syncStore.clearSync(query)
-            .then(() => storeToTest.pendingSyncEntities())
-            .then((result) => {
-              expect(result.length).to.equal(1);
-              expect(result[0].entityId).to.equal(entity2._id);
-              done();
-            }).catch(done);
-        });
+          it('should return only the entities, matching the query', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity1._id);
+            storeToTest.pendingSyncEntities(query)
+              .then((entities) => {
+                expect(entities.length).to.equal(1);
+                expect(entities[0].entityId).to.equal(entity1._id);
+                done();
+              }).catch(done);
+          });
 
-        it('pendingSyncEntities() should return only the entities waiting to be synced', (done) => {
-          storeToTest.pendingSyncEntities()
-            .then((entities) => {
-              expect(entities.length).to.equal(2);
-              entities.forEach((entity) => {
-                expect(entity.collection).to.equal(collectionName);
-                expect(entity.state.operation).to.equal('PUT');
-                expect([entity1._id, entity2._id]).to.include(entity.entityId);
-              });
-              done();
-            }).catch(done);
-        });
-
-        it('pendingSyncEntities() should return only the entities, matching the query', (done) => {
-          const query = new Kinvey.Query();
-          query.equalTo('_id', entity1._id);
-          storeToTest.pendingSyncEntities(query)
-            .then((entities) => {
-              expect(entities.length).to.equal(1);
-              expect(entities[0].entityId).to.equal(entity1._id);
-              done();
-            }).catch(done);
-        });
-
-        it('pendingSyncEntities() should return an empty array if there are no entities waiting to be synced', (done) => {
-          syncStore.clearSync()
-            .then(() => storeToTest.pendingSyncEntities())
-            .then((entities) => {
-              expect(entities).to.be.an.empty.array;
-              done();
-            }).catch(done);
+          it('should return an empty array if there are no entities waiting to be synced', (done) => {
+            syncStore.clearSync()
+              .then(() => storeToTest.pendingSyncEntities())
+              .then((entities) => {
+                expect(entities).to.be.an.empty.array;
+                done();
+              }).catch(done);
+          });
         });
       });
 

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -172,7 +172,7 @@ function testFunc() {
               .then(() => storeToTest.pendingSyncEntities())
               .then((result) => {
                 expect(result.length).to.equal(1);
-                expect(result[0].entityId).to.equal(entity2._id);
+                validateSyncEntity(result[0], 'PUT', entity2._id);
                 done();
               }).catch(done);
           });


### PR DESCRIPTION
#### Description
Add a few integration tests. Change some tests to use the Observable API, instead of promises, to make sure we have that covered on all methods of data stores. Group some tests in a describe block, instead of featuring the method being tested in their names.

Some tests are skipped, as they are about functionality which is not yet implemented.
