### PR TITLE
Datastores redesign stage 4, part 2 - improvements

### DIFF
--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -123,7 +123,6 @@ export class NetworkStore {
     if (!id) {
       return wrapInObservable((observer) => {
         observer.next(undefined); // TODO: decide on this behaviour
-        observer.complete();
       });
     }
 

--- a/src/core/datastore/persisters/browser/websql-sql-module.js
+++ b/src/core/datastore/persisters/browser/websql-sql-module.js
@@ -75,7 +75,7 @@ export class WebSqlSqlModule {
           const parameters = ['table', collection];
 
           return this.openTransaction(webSqlCollectionsMaster, query, parameters).then((response) => {
-            if (response.result.length === 0) {
+            if (response === 0) {
               return resolve([]);
             }
 

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -207,7 +207,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
     return this._getRepository()
       .then(repo => repo.delete(collection, deleteQuery, options))
       .then((deletedCount) => {
-        return this._syncManager.removeSyncEntitiesForIds(offlineEntities.map(e => e._id))
+        return this._syncManager.removeSyncItemsForIds(offlineEntities.map(e => e._id))
           .then(() => deletedCount);
       });
   }

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -81,7 +81,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
       return this._ensureCountBeforeRead(collection, 'fetch the entities', query)
         .then(() => super._processRead(collection, query, options))
         .then((entities) => {
-          offlineEntities = entities || []; // really?
+          offlineEntities = entities || []; // backwards compatibility
           observer.next(offlineEntities);
           return this._networkRepository.read(collection, query, options);
         })
@@ -98,7 +98,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
       const query = new Query().equalTo('_id', entityId);
       return this._ensureCountBeforeRead(collection, 'find the entity', query)
         .then(() => super._processReadById(collection, entityId, options))
-        .catch(err => this._catchNotFoundError(err))
+        .catch(err => this._catchNotFoundError(err)) // backwards compatibility
         .then((entity) => {
           observer.next(entity);
           offlineEntity = entity;
@@ -106,7 +106,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
         })
         .then((entity) => {
           observer.next(entity);
-          return this._replaceOfflineEntities(collection, ensureArray(offlineEntity), ensureArray(entity));
+          return this._replaceOfflineEntities(collection, offlineEntity, ensureArray(entity));
         });
     });
   }

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -104,7 +104,7 @@ export class SyncManager {
   clearSync(collection, query) {
     if (query) {
       return this._getEntityIdsForQuery(collection, query)
-        .then(entityIds => this._syncStateManager.removeSyncEntitiesForIds(entityIds));
+        .then(entityIds => this._syncStateManager.removeSyncItemsForIds(entityIds));
     }
     return this._syncStateManager.removeAllSyncItems(collection);
   }
@@ -126,8 +126,8 @@ export class SyncManager {
     return this._syncStateManager.removeSyncItemForEntityId(entityId);
   }
 
-  removeSyncEntitiesForIds(entityIds) {
-    return this._syncStateManager.removeSyncEntitiesForIds(entityIds);
+  removeSyncItemsForIds(entityIds) {
+    return this._syncStateManager.removeSyncItemsForIds(entityIds);
   }
 
   _getPushOpResult(entityId, operation) {

--- a/src/core/observable.js
+++ b/src/core/observable.js
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { rxSubscriber } from 'rxjs/symbol/rxSubscriber';
 import isFunction from 'lodash/isFunction';
-import { isDefined, isPromiseLike } from './utils';
+import { isDefined, isPromiseLike, wrapInPromise } from './utils';
 
 /**
  * @private
@@ -268,15 +268,16 @@ export class KinveyObservable extends Observable {
   }
 }
 
-export function wrapInObservable(promiseGeneratorOrPromise, completeAfter = true) {
-  const argIsPromise = isPromiseLike(promiseGeneratorOrPromise);
+export function wrapInObservable(promiseOrFunc, completeAfter = true) {
+  const argIsPromise = isPromiseLike(promiseOrFunc);
 
   const stream = KinveyObservable.create((observer) => {
     let promise;
     if (argIsPromise) {
-      promise = promiseGeneratorOrPromise;
+      promise = promiseOrFunc;
     } else {
-      promise = promiseGeneratorOrPromise(observer);
+      const funcResult = promiseOrFunc(observer);
+      promise = wrapInPromise(funcResult); // func can be sync or async
     }
 
     promise

--- a/test/integration/tests/crud-entity/common-crud.test.js
+++ b/test/integration/tests/crud-entity/common-crud.test.js
@@ -147,7 +147,7 @@ function testFunc() {
         });
 
         describe('findById()', () => {
-          it('should throw a NotFoundError if the id argument does not exist', (done) => {
+          it('should throw a NotFoundError if an entity with the given id does not exist', (done) => {
             const entityId = utilities.randomString();
             storeToTest.findById(entityId).toPromise()
               .then(() => done(new Error('Should not be called')))

--- a/test/integration/tests/crud-entity/common-crud.test.js
+++ b/test/integration/tests/crud-entity/common-crud.test.js
@@ -939,12 +939,9 @@ function testFunc() {
         describe('removeById()', () => {
           it('should throw an error if the id argument does not exist', (done) => {
             storeToTest.removeById(utilities.randomString())
+              .then(() => done(new Error('Should not be called')))
               .catch((error) => {
-                if (dataStoreType === Kinvey.DataStoreType.Network) {
-                  expect(error.name).to.contain(notFoundErrorName);
-                } else {
-                  expect(error).to.exist;
-                }
+                expect(error.name).to.contain(notFoundErrorName);
                 done();
               })
               .catch(done);

--- a/test/integration/tests/crud-entity/offline-crud.test.js
+++ b/test/integration/tests/crud-entity/offline-crud.test.js
@@ -110,18 +110,26 @@ function testFunc() {
       describe('clear()', () => {
         it('should remove the entities from the cache, which match the query', (done) => {
           const randomId = utilities.randomString();
+          const randomId2 = utilities.randomString();
+          const clearQuery = new Kinvey.Query();
+          clearQuery.equalTo('_id', randomId);
+
           cacheStore.save({ _id: randomId })
+            .then(() => syncStore.save({ _id: randomId2 }))
             .then(() => {
-              const query = new Kinvey.Query();
-              query.equalTo('_id', randomId);
-              return storeToTest.clear(query);
+              return storeToTest.clear(clearQuery);
             })
             .then((result) => {
               expect(result.count).to.equal(1);
               return syncStore.count().toPromise();
             })
             .then((count) => {
-              expect(count).to.equal(1);
+              expect(count).to.equal(2); // the item from beforeEach and randomId2
+              return storeToTest.pendingSyncEntities();
+            })
+            .then((syncItems) => {
+              expect(syncItems.length).to.equal(1);
+              expect(syncItems[0].entityId).to.equal(randomId2);
               return networkStore.count().toPromise();
             })
             .then((count) => {

--- a/test/integration/tests/crud-entity/offline-crud.test.js
+++ b/test/integration/tests/crud-entity/offline-crud.test.js
@@ -110,30 +110,55 @@ function testFunc() {
       describe('clear()', () => {
         it('should remove the entities from the cache, which match the query', (done) => {
           const randomId = utilities.randomString();
-          const randomId2 = utilities.randomString();
-          const clearQuery = new Kinvey.Query();
-          clearQuery.equalTo('_id', randomId);
-
           cacheStore.save({ _id: randomId })
-            .then(() => syncStore.save({ _id: randomId2 }))
             .then(() => {
-              return storeToTest.clear(clearQuery);
+              const query = new Kinvey.Query();
+              query.equalTo('_id', randomId);
+              return storeToTest.clear(query);
             })
             .then((result) => {
               expect(result.count).to.equal(1);
               return syncStore.count().toPromise();
             })
             .then((count) => {
-              expect(count).to.equal(2); // the item from beforeEach and randomId2
-              return storeToTest.pendingSyncEntities();
-            })
-            .then((syncItems) => {
-              expect(syncItems.length).to.equal(1);
-              expect(syncItems[0].entityId).to.equal(randomId2);
+              expect(count).to.equal(1);
               return networkStore.count().toPromise();
             })
             .then((count) => {
               expect(count).to.equal(2);
+              done();
+            })
+            .catch(done);
+        });
+
+        it('should remove sync entities only for entities, which match the query', (done) => {
+          const randomId = utilities.randomString();
+          const updatedEntity1 = {
+            _id: entity1._id,
+            someNewProperty: 'any value'
+          };
+
+          syncStore.update({ _id: randomId })
+            .then((result) => {
+              expect(result).to.deep.equal({ _id: randomId });
+              return syncStore.update(updatedEntity1);
+            })
+            .then((result) => {
+              expect(result).to.deep.equal(updatedEntity1);
+              return storeToTest.pendingSyncEntities();
+            })
+            .then((syncEntities) => {
+              expect(syncEntities.map(e => e.entityId).sort()).to.deep.equal([entity1._id, randomId].sort());
+              const query = new Kinvey.Query().equalTo('_id', entity1._id);
+              return storeToTest.clear(query);
+            })
+            .then((result) => {
+              expect(result).to.deep.equal({ count: 1 });
+              return storeToTest.pendingSyncEntities();
+            })
+            .then((result) => {
+              expect(result.length).to.equal(1);
+              expect(result[0].entityId).to.equal(randomId);
               done();
             })
             .catch(done);


### PR DESCRIPTION
**IMPORTANT:** This is to be reviewed only after stage 4, part 1 (PR #227).

#### Description
This adds improvements as per MLIBZ-2274 and MLIBZ-2275. A couple of small bug fixes, improvements and changes to tests.

#### Changes
Update clear() integration tests and unit tests to reflect the new behaviour - clearing sync items as well as collection entities. Some refactoring and bug fixing for sync, observables and offline storage.
