### PR TITLE
MLIBZ-2159: _id field not returned when specifying fields for a query

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -4,7 +4,7 @@ import { QueryError } from './errors';
 import { nested, isDefined, isNumber } from './utils';
 import { Log } from './log';
 
-const PROTECTED_FIELDS = ['_id', '_kmd', '_acl'];
+const PROTECTED_FIELDS = ['_id', '_acl'];
 const UNSUPPORTED_CONDITIONS = ['$nearSphere'];
 
 /**

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -4,6 +4,7 @@ import { QueryError } from './errors';
 import { nested, isDefined, isNumber } from './utils';
 import { Log } from './log';
 
+const PROTECTED_FIELDS = ['_id', '_kmd', '_acl'];
 const UNSUPPORTED_CONDITIONS = ['$nearSphere'];
 
 /**
@@ -799,11 +800,12 @@ export class Query {
 
     // Remove fields
     if (Array.isArray(json.fields) && json.fields.length > 0) {
+      const fields = Array.concat([], json.fields, PROTECTED_FIELDS);
       Log.debug('Removing fields from data', json.fields);
       data = data.map((item) => {
         const keys = Object.keys(item);
         keys.forEach((key) => {
-          if (json.fields.indexOf(key) === -1) {
+          if (fields.indexOf(key) === -1) {
             delete item[key];
           }
         });

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -1314,6 +1314,19 @@ describe('Query', () => {
       query.fields = ['desc'];
       expect(query.process(entities)).to.deep.equal([{ desc: 'Desc1' }, { desc: 'Desc2' }]);
     });
+
+    it('should not remove protected fields when fields are specified', () => {
+      const entities = [
+        { _id: '0', _acl: 'acl1', _kmd: 'kmd1', name: 'Name1', desc: 'Desc1' },
+        { _id: '1', _acl: 'acl2', _kmd: 'kmd2', name: 'Name2', desc: 'Desc2' }
+      ];
+      const query = new Query();
+      query.fields = ['desc'];
+      expect(query.process(entities)).to.deep.equal([
+        { _id: '0', _acl: 'acl1', _kmd: 'kmd1', desc: 'Desc1' },
+        { _id: '1', _acl: 'acl2', _kmd: 'kmd2', desc: 'Desc2' }
+      ]);
+    });
   });
 
   describe('toQueryString()', () => {

--- a/src/core/query.spec.js
+++ b/src/core/query.spec.js
@@ -1323,8 +1323,8 @@ describe('Query', () => {
       const query = new Query();
       query.fields = ['desc'];
       expect(query.process(entities)).to.deep.equal([
-        { _id: '0', _acl: 'acl1', _kmd: 'kmd1', desc: 'Desc1' },
-        { _id: '1', _acl: 'acl2', _kmd: 'kmd2', desc: 'Desc2' }
+        { _id: '0', _acl: 'acl1', desc: 'Desc1' },
+        { _id: '1', _acl: 'acl2', desc: 'Desc2' }
       ]);
     });
   });


### PR DESCRIPTION
#### Changes
- Added `const PROTECTED_FIELDS = ['_id', '_kmd', '_acl'];`
- Concatenated the specified fields array with the protected fields array

#### Tests
- Added unit test to verify protected fields are not removed when using a query with specified fields