### PR TITLE
Datastores redesign stage 4, part 3 - storage selection

### DIFF
--- a/packages/kinvey-html5-sdk/src/bundle.js
+++ b/packages/kinvey-html5-sdk/src/bundle.js
@@ -3,7 +3,6 @@ import { Html5HttpMiddleware } from '../../../src/html5/http';
 import { MobileIdentityConnect } from '../../../src/core/identity';
 import { Popup } from '../../../src/html5/popup';
 import pkg from '../package.json';
-import '../../../src/html5/offline-data-storage';
 
 // Setup racks
 NetworkRack.useHttpMiddleware(new Html5HttpMiddleware(pkg));

--- a/packages/kinvey-html5-sdk/src/index.js
+++ b/packages/kinvey-html5-sdk/src/index.js
@@ -1,3 +1,3 @@
-export * from './bundle';
 import * as Kinvey from './bundle';
+export * from './bundle';
 export { Kinvey };

--- a/packages/kinvey-nativescript-sdk/src/bundle.ts
+++ b/packages/kinvey-nativescript-sdk/src/bundle.ts
@@ -3,7 +3,6 @@ import { NetworkRack } from '../../../src/core/request';
 import { HttpMiddleware } from '../../../src/nativescript/http';
 import { Popup } from '../../../src/nativescript/popup';
 import pkg from '../package.json';
-import '../../../src/nativescript/offline-data-storage';
 
 // Setup racks
 NetworkRack.useHttpMiddleware(new HttpMiddleware(pkg));

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -5,8 +5,8 @@ import isNumber from 'lodash/isNumber';
 import isNaN from 'lodash/isNaN';
 import { KinveyError } from './errors';
 import { Log } from './log';
-import { isDefined, uuidv4, isValidStorageTypeValue } from './utils';
-import { storageType } from './datastore';
+import { isDefined, uuidv4, isValidStorageProviderValue } from './utils';
+import { storageProvider } from './datastore';
 
 const DEFAULT_TIMEOUT = 60000;
 const ACTIVE_USER_KEY = 'active_user';
@@ -149,7 +149,7 @@ export class Client {
      */
     this.activeUserStorage = new ActiveUserStorage();
 
-    this.storageType = config.storageType || storageType.inmemory;
+    this.storage = config.storage || storageProvider.inmemory;
   }
 
   /**
@@ -227,16 +227,16 @@ export class Client {
     this._defaultTimeout = timeout;
   }
 
-  get storageType() {
-    return this._storageType;
+  get storage() {
+    return this._storage;
   }
 
-  set storageType(value) {
-    if (!isValidStorageTypeValue(value)) {
-      throw new KinveyError('Please provide a valid list of supported storage types for this platform');
+  set storage(value) {
+    if (!isValidStorageProviderValue(value)) {
+      throw new KinveyError('Please provide a valid list of supported storage providers for this platform');
     }
 
-    this._storageType = value;
+    this._storage = value;
   }
 
   /**

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -6,7 +6,7 @@ import isNaN from 'lodash/isNaN';
 import { KinveyError } from './errors';
 import { Log } from './log';
 import { isDefined, uuidv4, isValidStorageProviderValue } from './utils';
-import { storageProvider } from './datastore';
+import { StorageProvider } from './datastore';
 
 const DEFAULT_TIMEOUT = 60000;
 const ACTIVE_USER_KEY = 'active_user';
@@ -149,7 +149,7 @@ export class Client {
      */
     this.activeUserStorage = new ActiveUserStorage();
 
-    this.storage = config.storage || storageProvider.inmemory;
+    this.storage = config.storage || StorageProvider.Memory;
   }
 
   /**

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -140,11 +140,6 @@ export class Client {
     this.defaultTimeout = isNumber(config.defaultTimeout) && config.defaultTimeout >= 0 ? config.defaultTimeout : DEFAULT_TIMEOUT;
 
     /**
-     * @type {?string[]}
-     */
-    this.storageProviders = config.storage;
-
-    /**
      * @private
      */
     this.activeUserStorage = new ActiveUserStorage();
@@ -233,7 +228,7 @@ export class Client {
 
   set storage(value) {
     if (!isValidStorageProviderValue(value)) {
-      throw new KinveyError('Please provide a valid list of supported storage providers for this platform');
+      throw new KinveyError('Please provide a valid set of supported storage providers for this platform');
     }
 
     this._storage = value;
@@ -258,7 +253,7 @@ export class Client {
       masterSecret: this.masterSecret,
       encryptionKey: this.encryptionKey,
       appVersion: this.appVersion,
-      storageProviders: this.storageProviders
+      storage: this.storage
     };
   }
 

--- a/src/core/datastore/repositories/index.js
+++ b/src/core/datastore/repositories/index.js
@@ -1,5 +1,5 @@
 export * from './repository';
-export * from './storage-type';
+export * from './storage-provider';
 export * from './offline-repositories';
 export * from './network-repository';
 export * from './repository-provider';

--- a/src/core/datastore/repositories/repository-provider.js
+++ b/src/core/datastore/repositories/repository-provider.js
@@ -4,7 +4,7 @@ import { Client } from '../../client';
 import { KinveyError } from '../../errors';
 import { InmemoryOfflineRepository } from './offline-repositories';
 import { NetworkRepository } from './network-repository';
-import { storageProvider } from './storage-provider';
+import { StorageProvider } from './storage-provider';
 import { ensureArray } from '../../utils';
 import { InmemoryCrudQueue } from '../utils';
 import { MemoryKeyValuePersister } from '../persisters';
@@ -20,8 +20,8 @@ const inmemoryRepoBuilder = (queue) => {
 const queue = new InmemoryCrudQueue();
 let _chosenRepoPromise;
 
-let availableStorages = {
-  [storageProvider.inmemory]: inmemoryRepoBuilder
+let _availableStorages = {
+  [StorageProvider.Memory]: inmemoryRepoBuilder
 };
 
 function _getRepoType() {
@@ -33,7 +33,7 @@ function _testRepoSupport(repo) {
 }
 
 function _getRepoForStorageProvider(storageProvider) {
-  const repoBuilder = availableStorages[storageProvider];
+  const repoBuilder = _availableStorages[storageProvider];
   if (!repoBuilder) {
     const errMsg = `The requested storage provider "${storageProvider}" is not available in this environment`;
     throw new KinveyError(errMsg);
@@ -81,11 +81,11 @@ function getNetworkRepository() {
 }
 
 function setSupportedRepoBuilders(repos) {
-  availableStorages = repos;
+  _availableStorages = repos;
 }
 
 function getSupportedStorages() {
-  return keys(availableStorages);
+  return keys(_availableStorages);
 }
 
 export const repositoryProvider = {

--- a/src/core/datastore/repositories/storage-provider.js
+++ b/src/core/datastore/repositories/storage-provider.js
@@ -1,4 +1,4 @@
-export const storageType = {
+export const storageProvider = {
   inmemory: 'inmemory',
   webSql: 'webSql',
   indexedDb: 'indexedDb',

--- a/src/core/datastore/repositories/storage-provider.js
+++ b/src/core/datastore/repositories/storage-provider.js
@@ -1,8 +1,8 @@
-export const storageProvider = {
-  inmemory: 'inmemory',
-  webSql: 'webSql',
-  indexedDb: 'indexedDb',
-  localStorage: 'localStorage',
-  sessionStorage: 'sessionStorage',
-  sqlite: 'sqlite'
+export const StorageProvider = {
+  Memory: 'Memory',
+  WebSQL: 'WebSQL',
+  IndexedDB: 'IndexedDB',
+  LocalStorage: 'LocalStorage',
+  SessionStorage: 'SessionStorage',
+  SQLite: 'SQLite'
 };

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,7 +5,7 @@ export { Aggregation } from './aggregation';
 export { AuthorizationGrant } from './identity';
 export { Client } from './client';
 export { CustomEndpoint } from './endpoint';
-export { DataStore, DataStoreType } from './datastore';
+export { DataStore, DataStoreType, SyncOperation } from './datastore';
 export { LiveService } from './live';
 export { Files } from './files';
 export { Log } from './log';

--- a/src/core/utils/misc.js
+++ b/src/core/utils/misc.js
@@ -28,8 +28,8 @@ export function ensureArray(obj) {
 
 export function isValidStorageProviderValue(value) {
   const supportedPersistances = repositoryProvider.getSupportedStorages();
-  value = ensureArray(value);
-  return value.length && value.every(type => supportedPersistances.some(v => type === v));
+  const valueAsArray = ensureArray(value);
+  return !!value && valueAsArray.length && valueAsArray.every(type => supportedPersistances.some(v => type === v));
 }
 
 export function forEachAsync(array, func) {
@@ -53,4 +53,11 @@ export function forEachAsync(array, func) {
         .catch(onAsyncOpDone);
     });
   });
+}
+
+export function useIfDefined(value, defaultValue) {
+  if (value !== undefined) {
+    return value;
+  }
+  return defaultValue;
 }

--- a/src/core/utils/misc.js
+++ b/src/core/utils/misc.js
@@ -26,7 +26,7 @@ export function ensureArray(obj) {
   return Array.isArray(obj) ? obj : [obj];
 }
 
-export function isValidStorageTypeValue(value) {
+export function isValidStorageProviderValue(value) {
   const supportedPersistances = repositoryProvider.getSupportedStorages();
   value = ensureArray(value);
   return value.length && value.every(type => supportedPersistances.some(v => type === v));

--- a/src/core/utils/misc.js
+++ b/src/core/utils/misc.js
@@ -56,7 +56,7 @@ export function forEachAsync(array, func) {
 }
 
 export function useIfDefined(value, defaultValue) {
-  if (value !== undefined) {
+  if (typeof value !== 'undefined') {
     return value;
   }
   return defaultValue;

--- a/src/html5/client.js
+++ b/src/html5/client.js
@@ -4,7 +4,7 @@ import { storage } from 'local-storage-fallback';
 import { Client } from '../core/client';
 import { KinveyError } from '../core/errors';
 import { Log } from '../core/log';
-import { isDefined } from '../core/utils';
+import { isDefined, useIfDefined } from '../core/utils';
 import { StorageProvider } from '../core/datastore';
 
 const defaultHtml5StorageProviderPrecedence = [
@@ -46,7 +46,7 @@ class ActiveUserStorage {
 export class Html5Client extends Client {
   static init(config) {
     config = cloneDeep(config);
-    config.storage = config.storage || defaultHtml5StorageProviderPrecedence;
+    config.storage = useIfDefined(config.storage, defaultHtml5StorageProviderPrecedence);
     const client = Client.init(config);
     client.activeUserStorage = new ActiveUserStorage();
     return client;

--- a/src/html5/client.js
+++ b/src/html5/client.js
@@ -5,13 +5,13 @@ import { Client } from '../core/client';
 import { KinveyError } from '../core/errors';
 import { Log } from '../core/log';
 import { isDefined } from '../core/utils';
-import { storageProvider } from '../core/datastore';
+import { StorageProvider } from '../core/datastore';
 
 const defaultHtml5StorageProviderPrecedence = [
-  storageProvider.webSql,
-  storageProvider.indexedDb,
-  storageProvider.localStorage,
-  storageProvider.sessionStorage
+  StorageProvider.WebSQL,
+  StorageProvider.IndexedDB,
+  StorageProvider.LocalStorage,
+  StorageProvider.SessionStorage
 ];
 
 class ActiveUserStorage {

--- a/src/html5/client.js
+++ b/src/html5/client.js
@@ -5,13 +5,13 @@ import { Client } from '../core/client';
 import { KinveyError } from '../core/errors';
 import { Log } from '../core/log';
 import { isDefined } from '../core/utils';
-import { storageType } from '../core/datastore';
+import { storageProvider } from '../core/datastore';
 
-const defaultHtml5StorageTypePrecedence = [
-  storageType.webSql,
-  storageType.indexedDb,
-  storageType.localStorage,
-  storageType.sessionStorage
+const defaultHtml5StorageProviderPrecedence = [
+  storageProvider.webSql,
+  storageProvider.indexedDb,
+  storageProvider.localStorage,
+  storageProvider.sessionStorage
 ];
 
 class ActiveUserStorage {
@@ -46,7 +46,7 @@ class ActiveUserStorage {
 export class Html5Client extends Client {
   static init(config) {
     config = cloneDeep(config);
-    config.storageType = config.storageType || defaultHtml5StorageTypePrecedence;
+    config.storage = config.storage || defaultHtml5StorageProviderPrecedence;
     const client = Client.init(config);
     client.activeUserStorage = new ActiveUserStorage();
     return client;

--- a/src/html5/index.js
+++ b/src/html5/index.js
@@ -1,1 +1,8 @@
+import pick from 'lodash/pick';
+import { StorageProvider as StorageProviderEnum, repositoryProvider } from '../core/datastore';
+import './offline-data-storage';
+
 export * from './kinvey';
+
+const supportedStorageProviders = repositoryProvider.getSupportedStorages();
+export const StorageProvider = pick(StorageProviderEnum, supportedStorageProviders);

--- a/src/html5/offline-data-storage.js
+++ b/src/html5/offline-data-storage.js
@@ -2,7 +2,7 @@ import { Html5Client } from './client';
 
 import {
   repositoryProvider,
-  storageType,
+  storageProvider,
   KeyValueStoreOfflineRepository,
   SqlKeyValueStorePersister,
   InmemoryOfflineRepository,
@@ -33,10 +33,10 @@ const sessionStorageBuilder = (queue) => {
 };
 
 const repoConstructors = {
-  [storageType.webSql]: webSqlBuilder,
-  [storageType.indexedDb]: indexedDbBuilder,
-  [storageType.localStorage]: localStorageBuilder,
-  [storageType.sessionStorage]: sessionStorageBuilder
+  [storageProvider.webSql]: webSqlBuilder,
+  [storageProvider.indexedDb]: indexedDbBuilder,
+  [storageProvider.localStorage]: localStorageBuilder,
+  [storageProvider.sessionStorage]: sessionStorageBuilder
 };
 
 repositoryProvider.setSupportedRepoBuilders(repoConstructors);

--- a/src/html5/offline-data-storage.js
+++ b/src/html5/offline-data-storage.js
@@ -2,7 +2,7 @@ import { Html5Client } from './client';
 
 import {
   repositoryProvider,
-  storageProvider,
+  StorageProvider,
   KeyValueStoreOfflineRepository,
   SqlKeyValueStorePersister,
   InmemoryOfflineRepository,
@@ -33,10 +33,10 @@ const sessionStorageBuilder = (queue) => {
 };
 
 const repoConstructors = {
-  [storageProvider.webSql]: webSqlBuilder,
-  [storageProvider.indexedDb]: indexedDbBuilder,
-  [storageProvider.localStorage]: localStorageBuilder,
-  [storageProvider.sessionStorage]: sessionStorageBuilder
+  [StorageProvider.WebSQL]: webSqlBuilder,
+  [StorageProvider.IndexedDB]: indexedDbBuilder,
+  [StorageProvider.LocalStorage]: localStorageBuilder,
+  [StorageProvider.SessionStorage]: sessionStorageBuilder
 };
 
 repositoryProvider.setSupportedRepoBuilders(repoConstructors);

--- a/src/nativescript/client.ts
+++ b/src/nativescript/client.ts
@@ -5,7 +5,7 @@ import { KinveyError } from '../core/errors';
 import { isDefined } from '../core/utils';
 import { Log } from '../core/log';
 import { SecureStorage } from './secure';
-import { storageType } from '../core/datastore';
+import { storageProvider } from '../core/datastore';
 
 const storage = new SecureStorage();
 
@@ -50,7 +50,7 @@ class ActiveUserStorage {
 export class Client extends CoreClient {
   static init(config) {
     config = cloneDeep(config);
-    config.storageType = config.storageType || storageType.sqlite;
+    config.storage = config.storage || storageProvider.sqlite;
     const client = CoreClient.init(config);
     client.activeUserStorage = new ActiveUserStorage();
     return client;

--- a/src/nativescript/client.ts
+++ b/src/nativescript/client.ts
@@ -2,10 +2,10 @@ import * as cloneDeep from 'lodash/cloneDeep';
 
 import { Client as CoreClient } from '../core/client';
 import { KinveyError } from '../core/errors';
-import { isDefined } from '../core/utils';
+import { isDefined, useIfDefined } from '../core/utils';
 import { Log } from '../core/log';
 import { SecureStorage } from './secure';
-import { storageProvider } from '../core/datastore';
+import { StorageProvider } from '../core/datastore';
 
 const storage = new SecureStorage();
 
@@ -50,7 +50,7 @@ class ActiveUserStorage {
 export class Client extends CoreClient {
   static init(config) {
     config = cloneDeep(config);
-    config.storage = config.storage || storageProvider.sqlite;
+    config.storage = useIfDefined(config.storage, StorageProvider.SQLite);
     const client = CoreClient.init(config);
     client.activeUserStorage = new ActiveUserStorage();
     return client;

--- a/src/nativescript/index.ts
+++ b/src/nativescript/index.ts
@@ -1,2 +1,9 @@
+import pick from 'lodash/pick';
+import { StorageProvider as StorageProviderEnum, repositoryProvider } from '../core/datastore';
+import './offline-data-storage';
+
 export * from './kinvey';
 export { Push } from './push';
+
+const supportedStorageProviders = repositoryProvider.getSupportedStorages();
+export const StorageProvider = pick(StorageProviderEnum, supportedStorageProviders);

--- a/src/nativescript/index.ts
+++ b/src/nativescript/index.ts
@@ -1,4 +1,4 @@
-import pick from 'lodash/pick';
+import * as pick from 'lodash/pick';
 import { StorageProvider as StorageProviderEnum, repositoryProvider } from '../core/datastore';
 import './offline-data-storage';
 

--- a/src/nativescript/offline-data-storage.ts
+++ b/src/nativescript/offline-data-storage.ts
@@ -1,6 +1,6 @@
 import {
   repositoryProvider,
-  storageProvider,
+  StorageProvider,
   KeyValueStoreOfflineRepository,
   SqlKeyValueStorePersister
 } from '../core/datastore';
@@ -14,7 +14,7 @@ const sqliteStorageBuilder = (queue) => {
 };
 
 const repoConstructors = {
-  [storageProvider.sqlite]: sqliteStorageBuilder
+  [StorageProvider.SQLite]: sqliteStorageBuilder
 };
 
 repositoryProvider.setSupportedRepoBuilders(repoConstructors);

--- a/src/nativescript/offline-data-storage.ts
+++ b/src/nativescript/offline-data-storage.ts
@@ -1,6 +1,6 @@
 import {
   repositoryProvider,
-  storageType,
+  storageProvider,
   KeyValueStoreOfflineRepository,
   SqlKeyValueStorePersister
 } from '../core/datastore';
@@ -14,7 +14,7 @@ const sqliteStorageBuilder = (queue) => {
 };
 
 const repoConstructors = {
-  [storageType.sqlite]: sqliteStorageBuilder
+  [storageProvider.sqlite]: sqliteStorageBuilder
 };
 
 repositoryProvider.setSupportedRepoBuilders(repoConstructors);


### PR DESCRIPTION
#### Description
MLIBZ-2329. Change the selection of storage to fit the implementation in master currently. There is also a slight change to an integration test about `clear()`. I separated testing deletion of collection entities from deletion of sync items. This is one of the changes with the current implementation that are coming with the redesign.

#### Changes
Rename the storage enum, expose it in the same way (with only supported storages for the platform).