### PR TITLE
(Query -> isSupportedOffline) Check that a value is an object before calling Object.keys

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -197,7 +197,11 @@ export class Query {
       if (supported) {
         const value = this.filter[key];
         return UNSUPPORTED_CONDITIONS.some((unsupportedConditions) => {
-          if (!value || typeof value !== 'object') {
+          if (!value) {
+            return true;
+          }
+
+          if (typeof value !== 'object') {
             return true;
           }
 

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -197,7 +197,7 @@ export class Query {
       if (supported) {
         const value = this.filter[key];
         return UNSUPPORTED_CONDITIONS.some((unsupportedConditions) => {
-          if (!value) {
+          if (!value || typeof value !== 'object') {
             return true;
           }
 


### PR DESCRIPTION
#### Description
When utilizing a `Cache` collection, requests are failing in this function block due to the `value` being either a string or a boolean, and are being passed into `Object.keys`.

For some reference, when this issue was encountered, the value for `this.filter` was:
```js
{ collection: "GenericUser" }
```

Which is the name of the Cache collection we are calling `find` on. `value`, in this case, will equal `"GenericUser"`, which is breaking when being passed to `Object.keys`.

I haven't done too much digging to see whether this was an issue with how `CacheRequest` is passing the current query, or if this is just an edge case that should be included in this function.. any insight would be great!

#### Changes
- Add a type check to make sure `value` is an object before calling `Object.keys` on it.
