### PR TITLE
MLIBZ-2385 Incorrect sync item count

### DIFF
--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -73,10 +73,7 @@ export class CacheStore extends NetworkStore {
    * @return  {Promise}                                                         Promise
    */
   pendingSyncCount(query) {
-    if (query) {
-      return this.syncManager.getSyncItemCountByEntityQuery(this.collection, query);
-    }
-    return this.syncManager.getSyncItemCount(this.collection);
+    return this.syncManager.getSyncItemCountByEntityQuery(this.collection, query);
   }
 
   pendingSyncEntities(query) {
@@ -111,7 +108,7 @@ export class CacheStore extends NetworkStore {
    */
   pull(query, options = {}) {
     options = assign({ useDeltaFetch: this.useDeltaFetch }, options);
-    return this.pendingSyncCount(query)
+    return this.syncManager.getSyncItemCountByEntityQuery(this.collection, query)
       .then((count) => {
         if (count > 0) {
           return this.syncManager.push(this.collection, query);

--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -111,13 +111,9 @@ export class CacheStore extends NetworkStore {
    */
   pull(query, options = {}) {
     options = assign({ useDeltaFetch: this.useDeltaFetch }, options);
-    // TODO: the query issue must be resolved - entity or sync entity
-    return this.syncManager.getSyncItemCountByEntityQuery(this.collection, query)
+    return this.pendingSyncCount(query)
       .then((count) => {
         if (count > 0) {
-          // TODO: I think this should happen, but keeping current behaviour
-          // const msg = `There are ${count} entities awaiting push. Please push before you attempt to pull`;
-          // return Promise.reject(new KinveyError(msg));
           return this.syncManager.push(this.collection, query);
         }
         return Promise.resolve();

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -74,6 +74,10 @@ export class SyncManager {
 
   // TODO: this method is temporray, pending fix for MLIBZ-2177
   getSyncItemCountByEntityQuery(collection, query) {
+    if (!query) {
+      return this._syncStateManager.getSyncItemCount(collection);
+    }
+
     return this._getOfflineRepo()
       .then(repo => repo.read(collection, query))
       .then((entities) => {
@@ -82,8 +86,8 @@ export class SyncManager {
       });
   }
 
+  // TODO: this only returns nondeleted entities - pending fix for MLIBZ-2177
   getSyncEntities(collection, query) {
-    // TODO: this only returns nondeleted entities - pending fix for MLIBZ-2177
     return this._getOfflineRepo()
       .then(repo => repo.read(collection, query))
       .then((entities = []) => {

--- a/src/core/datastore/sync/sync-state-manager.js
+++ b/src/core/datastore/sync/sync-state-manager.js
@@ -13,7 +13,8 @@ import {
   generateEntityId,
   getTagFromCollectionName,
   formTaggedCollectionName,
-  stripTagFromCollectionName
+  stripTagFromCollectionName,
+  collectionHasTag
 } from '../utils';
 
 // imported for typings
@@ -123,8 +124,10 @@ export class SyncStateManager {
   _getCollectionFilter(collection) {
     const result = new Query();
     result.equalTo('collection', collection)
-      .or()
-      .equalTo('collection', stripTagFromCollectionName(collection));
+    if (collectionHasTag(collection)) {
+      result.or()
+        .equalTo('collection', stripTagFromCollectionName(collection));
+    }
     return result;
   }
 

--- a/src/core/datastore/utils/utils.js
+++ b/src/core/datastore/utils/utils.js
@@ -34,6 +34,10 @@ export function isValidDataStoreTag(value) {
   return isNonemptyString(value) && regexp.test(value);
 }
 
+export function collectionHasTag(collection) {
+  return collection.indexOf(dataStoreTagSeparator) >= 0;
+}
+
 export function formTaggedCollectionName(collection, tag) {
   if (tag) {
     return `${collection}${dataStoreTagSeparator}${tag}`;

--- a/src/core/datastore/working-with-data-tests/data-stores-sync-manager.spec.js
+++ b/src/core/datastore/working-with-data-tests/data-stores-sync-manager.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 
 import { DataStoreType } from '../datastore';
 import { Query } from '../../query';
-import { datastoreFactory, createPromiseSpy } from './utils';
+import { datastoreFactory, createPromiseSpy, validateSpyCalls } from './utils';
 
 const collection = 'books';
 const optionKeyName = 'test';
@@ -47,7 +47,7 @@ describe('Data stores delegate correctly to sync manager', () => {
         const buildStore = datastoreFactory[storeType];
         store = buildStore(collection);
         // avoid proxyquire, since it can't reliably stub syncManagerProvider
-        // in CacheStore when requiring SyncManager
+        // in CacheStore when requiring SyncStore
         store.syncManager = syncManagerMock;
       });
 
@@ -63,8 +63,8 @@ describe('Data stores delegate correctly to sync manager', () => {
       it('pendingSyncCount() with NO query', () => {
         return store.pendingSyncCount()
           .then(() => {
-            const spy = syncManagerMock.getSyncItemCount;
-            validateSyncManagerCall(spy);
+            const spy = syncManagerMock.getSyncItemCountByEntityQuery;
+            validateSpyCalls(spy, 1, [collection, undefined])
           });
       });
 

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -341,7 +341,9 @@ function testFunc() {
                 return networkStore.find().toPromise()
                   .then((result) => {
                     expect(result.length).to.equal(3); // the nameless entity from setup
-                    expect(_.find(result, e => e._id === entity2._id)).to.exist;
+                    const expectedEntity2 = _.find(result, e => e._id === entity2._id);
+                    expect(expectedEntity2).to.exist;
+                    expect(expectedEntity2.newProperty).to.equal(updatedEntity2.newProperty);
                     expect(_.find(result, e => e._id === entity3._id)).to.exist;
                     done();
                   });
@@ -361,7 +363,9 @@ function testFunc() {
                   .then((result) => {
                     expect(result.length).to.equal(2); // the nameless entity from setup
                     expect(_.find(result, e => e._id === entity1._id)).to.exist;
-                    expect(_.find(result, e => e._id === entity2._id)).to.exist;
+                    const expectedEntity2 = _.find(result, e => e._id === entity2._id);
+                    expect(expectedEntity2).to.exist;
+                    expect(expectedEntity2.newProperty).to.equal(undefined);
                     expect(_.find(result, e => e._id === entity3._id)).to.not.exist;
                     done();
                   });

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -11,7 +11,17 @@ function testFunc() {
   const validatePushOperation = (result, createdItem, modifiedItem, deletedItem, expectedServerItemsCount) => {
     expect(result.length).to.equal(3);
     result.forEach((record) => {
-      expect(record.operation).to.equal(record._id === deletedItem._id ? 'DELETE' : 'PUT');
+      let expectedOperation;
+      if (record._id === createdItem._id) {
+        expectedOperation = 'POST';
+      } else if (record._id === modifiedItem._id) {
+        expectedOperation = 'PUT';
+      } else if (record._id === deletedItem._id) {
+        expectedOperation = 'DELETE';
+      } else {
+        throw new Error('Unexpected record id');
+      }
+      expect(record.operation).to.equal(expectedOperation);
       expect([createdItem._id, modifiedItem._id, deletedItem._id]).to.include(record._id);
       if (record.operation !== 'DELETE') {
         utilities.assertEntityMetadata(record.entity);
@@ -93,9 +103,16 @@ function testFunc() {
       describe('Pending sync queue operations', () => {
         beforeEach((done) => {
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => syncStore.save(entity1))
-            .then(() => syncStore.save(entity2))
-            .then(() => cacheStore.save(entity3))
+            .then(() => {
+              // set up a pending update
+              return cacheStore.create(entity1)
+                .then(() => syncStore.update(entity1))
+            })
+            .then(() => syncStore.create(entity2)) // set up a pending create
+            .then(() => {
+              return cacheStore.create(entity3)
+                .then(() => syncStore.removeById(entity3._id)) // set up a pending delete
+            })
             .then(() => done())
             .catch(done);
         });
@@ -104,13 +121,24 @@ function testFunc() {
           it('should return the count of the entities waiting to be synced', (done) => {
             storeToTest.pendingSyncCount()
               .then((count) => {
-                expect(count).to.equal(2);
+                expect(count).to.equal(3);
                 done();
               })
               .catch(done);
           });
 
-          it('should return the count of the entities, matching the query', (done) => {
+          it('should return the count of the entities, matching the query, for a create operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity2._id);
+            storeToTest.pendingSyncCount(query)
+              .then((count) => {
+                expect(count).to.equal(1);
+                done();
+              })
+              .catch(done);
+          });
+
+          it('should return the count of the entities, matching the query, for an update operation', (done) => {
             const query = new Kinvey.Query();
             query.equalTo('_id', entity1._id);
             storeToTest.pendingSyncCount(query)
@@ -121,24 +149,16 @@ function testFunc() {
               .catch(done);
           });
 
-          // CacheStore should have the same behavior, but it's difficult to simulate, since it only happens when the network request fails
-          if (dataStoreType === Kinvey.DataStoreType.Sync) {
-            // pending fix for MLIBZ-2177
-            it.skip('should return the count of matching entities even if they are deleted', (done) => {
-              storeToTest.removeById(entity1._id)
-                .then((result) => {
-                  expect(result).to.deep.equal({ count: 1 });
-                  const query = new Kinvey.Query();
-                  query.equalTo('_id', entity1._id);
-                  return storeToTest.pendingSyncCount(query);
-                })
-                .then((count) => {
-                  expect(count).to.equal(1);
-                  done();
-                })
-                .catch(done);
-            });
-          }
+          it.skip('should return the count of the entities, matching the query, for a delete operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity3._id);
+            storeToTest.pendingSyncCount(query)
+              .then((count) => {
+                expect(count).to.equal(1);
+                done();
+              })
+              .catch(done);
+          });
         });
 
         describe('clearSync()', () => {
@@ -151,16 +171,55 @@ function testFunc() {
               }).catch(done);
           });
 
-          it('should clear only the items, matching the query from the pending sync queue', (done) => {
+          it('should clear only the items, matching the query from the pending sync queue, for a create operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity2._id);
+            syncStore.clearSync(query)
+              .then((result) => {
+                expect(result).to.deep.equal(1);
+                return storeToTest.pendingSyncEntities();
+              })
+              .then((result) => {
+                expect(result.length).to.equal(1); // pending fix for MLIBZ-2177, should be 2
+                validateSyncEntity(result[0], 'PUT', entity1._id);
+                done();
+              })
+              .catch(done);
+          });
+
+          it('should clear only the items, matching the query from the pending sync queue, for an update operation', (done) => {
             const query = new Kinvey.Query();
             query.equalTo('_id', entity1._id);
             syncStore.clearSync(query)
-              .then(() => storeToTest.pendingSyncEntities())
               .then((result) => {
-                expect(result.length).to.equal(1);
-                validateSyncEntity(result[0], 'PUT', entity2._id);
+                expect(result).to.deep.equal(1);
+                return storeToTest.pendingSyncEntities();
+              })
+              .then((result) => {
+                expect(result.length).to.equal(1); // pending fix for MLIBZ-2177, should be 2
+                validateSyncEntity(result[0], 'POST', entity2._id);
                 done();
-              }).catch(done);
+              })
+              .catch(done);
+          });
+
+          it.skip('should clear only the items, matching the query from the pending sync queue, for a delete operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity3._id);
+            syncStore.clearSync(query)
+              .then((result) => {
+                expect(result).to.deep.equal(1); // pending fix for MLIBZ-2177
+                return storeToTest.pendingSyncEntities();
+              })
+              .then((result) => {
+                expect(result.length).to.equal(2);
+                const updatedEntity = result.find(e => e.state.operation === 'PUT');
+                const createdEntity = result.find(e => e.state.operation === 'POST');
+                validateSyncEntity(updatedEntity, 'PUT', entity1._id);
+                validateSyncEntity(createdEntity, 'POST', entity2._id);
+                done();
+              })
+              .catch(done);
           });
         });
 
@@ -168,16 +227,29 @@ function testFunc() {
           it('should return only the entities waiting to be synced', (done) => {
             storeToTest.pendingSyncEntities()
               .then((entities) => {
-                expect(entities.length).to.equal(2);
-                entities.forEach((entity) => {
-                  validateSyncEntity(entity, 'PUT', [entity1._id, entity2._id]);
-                });
+                expect(entities.length).to.equal(2); // pending fix for MLIBZ-2177, it should be 3
+                const updatedEntity = entities.find(e => e.state.operation === 'PUT');
+                const createdEntity = entities.find(e => e.state.operation === 'POST');
+                validateSyncEntity(updatedEntity, 'PUT', entity1._id);
+                validateSyncEntity(createdEntity, 'POST', entity2._id);
                 done();
               })
               .catch(done);
           });
 
-          it('should return only the entities, matching the query', (done) => {
+          it('should return only the entities, matching the query for a create operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity2._id);
+            storeToTest.pendingSyncEntities(query)
+              .then((entities) => {
+                expect(entities.length).to.equal(1);
+                validateSyncEntity(entities[0], 'POST', entity2._id);
+                done();
+              })
+              .catch(done);
+          });
+
+          it('should return only the entities, matching the query for an update operation', (done) => {
             const query = new Kinvey.Query();
             query.equalTo('_id', entity1._id);
             storeToTest.pendingSyncEntities(query)
@@ -189,25 +261,17 @@ function testFunc() {
               .catch(done);
           });
 
-          // CacheStore should have the same behavior, but it's difficult to simulate, since it only happens when the network request fails
-          if (dataStoreType === Kinvey.DataStoreType.Sync) {
-            // pending fix for MLIBZ-2177
-            it.skip('should return the matching entities, even if they are deleted', (done) => {
-              storeToTest.removeById(entity1._id)
-                .then((result) => {
-                  expect(result).to.deep.equal({ count: 1 });
-                  const query = new Kinvey.Query();
-                  query.equalTo('_id', entity1._id);
-                  return storeToTest.pendingSyncEntities(query);
-                })
-                .then((syncEntities) => {
-                  expect(syncEntities.length).to.equal(1);
-                  validateSyncEntity(syncEntities[0], 'DELETE', entity1._id);
-                  done();
-                })
-                .catch(done);
-            });
-          }
+          it.skip('should return only the entities, matching the query for a delete operation', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity3._id);
+            storeToTest.pendingSyncEntities(query)
+              .then((entities) => {
+                expect(entities.length).to.equal(1);
+                validateSyncEntity(entities[0], 'DELETE', entity3._id);
+                done();
+              })
+              .catch(done);
+          });
 
           it('should return an empty array if there are no entities waiting to be synced', (done) => {
             syncStore.clearSync()
@@ -228,11 +292,11 @@ function testFunc() {
           updatedEntity2 = Object.assign({ newProperty: utilities.randomString() }, entity2);
           // adding three items, eligible for sync and one item, which should not be synced
           utilities.cleanUpCollectionData(collectionName)
-            .then(() => syncStore.save(entity1))
+            .then(() => syncStore.create(entity1)) // set up a created entity
             .then(() => cacheStore.save(entity2))
             .then(() => cacheStore.save(entity3))
-            .then(() => syncStore.save(updatedEntity2))
-            .then(() => syncStore.removeById(entity3._id))
+            .then(() => syncStore.save(updatedEntity2)) // set up an updated entity
+            .then(() => syncStore.removeById(entity3._id)) // set up a deleted entity
             .then(() => cacheStore.save({}))
             .then(() => done())
             .catch(done);
@@ -246,7 +310,7 @@ function testFunc() {
               .catch(done);
           });
 
-          it('should push to the backend only the entities matching the query', (done) => {
+          it('should push to the backend only the entities matching the query, when operation is "create"', (done) => {
             const query = new Kinvey.Query();
             query.equalTo('_id', entity1._id);
             storeToTest.push(query)
@@ -256,8 +320,49 @@ function testFunc() {
 
                 return networkStore.find().toPromise()
                   .then((result) => {
-                    expect(_.find(result, (entity) => { return entity._id === entity1._id; })).to.exist;
-                    expect(_.find(result, (entity) => { return entity._id === entity3._id; })).to.exist;
+                    expect(result.length).to.equal(4); // the nameless entity from setup
+                    expect(_.find(result, e => e._id === entity1._id)).to.exist;
+                    expect(_.find(result, e => e._id === entity2._id)).to.exist;
+                    expect(_.find(result, e => e._id === entity3._id)).to.exist;
+                    done();
+                  });
+              })
+              .catch(done);
+          });
+
+          it('should push to the backend only the entities matching the query, when operation is "update"', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity2._id);
+            storeToTest.push(query)
+              .then((result) => {
+                expect(result.length).to.equal(1);
+                expect(result[0]._id).to.equal(entity2._id);
+
+                return networkStore.find().toPromise()
+                  .then((result) => {
+                    expect(result.length).to.equal(3); // the nameless entity from setup
+                    expect(_.find(result, e => e._id === entity2._id)).to.exist;
+                    expect(_.find(result, e => e._id === entity3._id)).to.exist;
+                    done();
+                  });
+              })
+              .catch(done);
+          });
+
+          it.skip('should push to the backend only the entities matching the query, when operation is "delete"', (done) => {
+            const query = new Kinvey.Query();
+            query.equalTo('_id', entity3._id);
+            storeToTest.push(query)
+              .then((result) => {
+                expect(result.length).to.equal(1);
+                expect(result[0]._id).to.equal(entity3._id);
+
+                return networkStore.find().toPromise()
+                  .then((result) => {
+                    expect(result.length).to.equal(2); // the nameless entity from setup
+                    expect(_.find(result, e => e._id === entity1._id)).to.exist;
+                    expect(_.find(result, e => e._id === entity2._id)).to.exist;
+                    expect(_.find(result, e => e._id === entity3._id)).to.not.exist;
                     done();
                   });
               })


### PR DESCRIPTION
#### Description
Querying for deleted entities is still a bit unclear ([MLIBZ-2177](https://kinvey.atlassian.net/browse/MLIBZ-2177)), so the special case where no query is provided needs to be handled explicitly and this was missing from the `pull()` method.

Also added a tiny optimization for the type of query being built for sync items. This has to do with [the difference](https://hackmd.io/IbBmGMAYFYGYBMC0B2ARgFgIyPeUBORVaVZRWWXLdfTcWZIA) that the collection name of sync items now contains the tag. So the filter needs to match the tagged or untagged collection name (for backwards compatibility), so it has an "or" condition. But when the collection being used doesn't have a tag in the first place, it would result in a redundant "or", so I removed it to speed up inmemory filtering. This can be removed in a future version, since it's unlikely sync items haven't been synced for that long, so all new sync items will have the new collection name.

#### Changes
Use different method for sync entity count, depending on the presence of a query. Only add "or" filter when using a tagged collection.
