### PR TITLE
Export LiveService Correctly

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -6,7 +6,7 @@ export { AuthorizationGrant } from './identity';
 export { Client } from './client';
 export { CustomEndpoint } from './endpoint';
 export { DataStore, DataStoreType, SyncOperation } from './datastore';
-export { LiveService } from './live';
+export { LiveServiceFacade as LiveService } from './live';
 export { Files } from './files';
 export { Log } from './log';
 export { Metadata } from './metadata';

--- a/src/core/live/collection/live-collection-manager.js
+++ b/src/core/live/collection/live-collection-manager.js
@@ -66,7 +66,7 @@ export class LiveCollectionManager {
    * @param {string} path
    */
   _makeSubscriptionRequest(collectionName, path) {
-    return KinveyRequest.executeShort({
+    return KinveyRequest.execute({
       method: RequestMethod.POST,
       pathname: `/appdata/${this._client.appKey}/${collectionName}/${path}`,
       body: { deviceId: this._client.deviceId }

--- a/src/core/live/live-service-facade.js
+++ b/src/core/live/live-service-facade.js
@@ -1,4 +1,5 @@
 import { Client } from '../client';
+import { Stream } from './user-to-user';
 import { getLiveService } from './live-service';
 
 function _getLiveService() {
@@ -10,7 +11,7 @@ function _getLiveService() {
  * Attaches a handler for connection status updates
  * @param {function} func
  */
-export function onConnectionStatusUpdates(func) {
+function onConnectionStatusUpdates(func) {
   _getLiveService().onConnectionStatusUpdates(func);
 }
 
@@ -19,13 +20,20 @@ export function onConnectionStatusUpdates(func) {
  * If no handler is specified, removes all handlers
  * @param {function} [func]
  */
-export function offConnectionStatusUpdates(func) {
+function offConnectionStatusUpdates(func) {
   _getLiveService().offConnectionStatusUpdates(func);
 }
 
 /**
  * Checks whether live service is ready to subscribe or publish messages
  */
-export function isInitialized() {
+function isInitialized() {
   return _getLiveService().isInitialized();
 }
+
+export const LiveServiceFacade = {
+  Stream,
+  onConnectionStatusUpdates,
+  offConnectionStatusUpdates,
+  isInitialized
+};

--- a/src/core/live/live-service.js
+++ b/src/core/live/live-service.js
@@ -355,7 +355,7 @@ export class LiveService {
    * @returns {Promise}
    */
   _makeUserManagementRequest(userId, path) {
-    return KinveyRequest.executeShort({
+    return KinveyRequest.execute({
       method: RequestMethod.POST,
       pathname: `/user/${this._client.appKey}/${userId}/${path}`,
       body: { deviceId: this._client.deviceId }

--- a/src/core/live/user-to-user/stream.js
+++ b/src/core/live/user-to-user/stream.js
@@ -255,7 +255,7 @@ export class Stream {
    * @returns {Promise}
    */
   _makeStreamRequest(path, method, body) {
-    return KinveyRequest.executeShort({
+    return KinveyRequest.execute({
       method: method,
       pathname: `/stream/${this._client.appKey}/${this.name}/${path}`,
       body: body


### PR DESCRIPTION
We should be exporting `live/live-service-facade.js` instead of `live/live-service.js` on the `Kinvey` namespace.