### PR TITLE
MLIBZ-2386 Query.process() when "fields" modifier is present

### DIFF
--- a/src/core/query.js
+++ b/src/core/query.js
@@ -800,7 +800,7 @@ export class Query {
 
     // Remove fields
     if (Array.isArray(json.fields) && json.fields.length > 0) {
-      const fields = Array.concat([], json.fields, PROTECTED_FIELDS);
+      const fields = PROTECTED_FIELDS.concat(json.fields);
       Log.debug('Removing fields from data', json.fields);
       data = data.map((item) => {
         const keys = Object.keys(item);


### PR DESCRIPTION
#### Description
 Fix concatenation of mandatory and user selected fields in Query.process(). Unit tests for this use case exist, but pass. The reason for this is the call to babel-polyfill, which does [this](https://github.com/babel/babel/blob/6.x/packages/babel-polyfill/src/index.js#L26). babel-polyfill is not used/bundled in the SDK code, so this fails elsewhere. I feel fixing this is out of scope for this PR and have logged it here: [MLIBZ-2391](https://kinvey.atlassian.net/browse/MLIBZ-2391)

#### Changes
Use the instance method `concat` of the existing `PROTECTED_FIELDS` array, to join the two arrays. The method does not modify the arrays, it produces a new one.
