### PR TITLE
feat(nativescript): Allow calling Kinvey.init without arguments

### DIFF
--- a/src/kinvey.d.ts
+++ b/src/kinvey.d.ts
@@ -8,8 +8,8 @@ import {
 export namespace Kinvey {
   export let appVersion: string;
 
-  export function initialize(config: ClientConfig): Promise < User > ;
-  export function init(config: ClientConfig): Client;
+  export function initialize(config?: ClientConfig): Promise < User > ;
+  export function init(config?: ClientConfig): Client;
 
   interface PingResponse {
     version: string;

--- a/src/nativescript/kinvey.ts
+++ b/src/nativescript/kinvey.ts
@@ -3,12 +3,38 @@ import * as url from 'url';
 import { isDefined } from '../core/utils';
 import { KinveyError } from '../core/errors';
 import { RequestMethod } from '../core/request';
+import { knownFolders, path, File } from 'tns-core-modules/file-system';
 import { Client } from './client';
 
 const USERS_NAMESPACE = 'user';
 const ACTIVE_USER_COLLECTION_NAME = 'kinvey_active_user';
+const PLUGIN_NAME = 'kinvey-nativescript-sdk';
+
+/**
+ * Gets settings persisted in package.json file (inside <project dir>/app/package.json)
+ * @returns The data from pluginsData['kinvey-nativescript-sdk'].config of app's package.json.
+ */
+function getDataFromPackageJson(): { appKey: string, appSecret: string, masterSecret: string } {
+  try {
+    const currentAppDir = knownFolders.currentApp();
+    const packageJsonFile = currentAppDir.getFile('package.json');
+    const packageJsonData = JSON.parse(packageJsonFile.readTextSync());
+
+    const pluginsData = packageJsonData && packageJsonData.pluginsData;
+    const kinveyNativeScriptSdkData = pluginsData && pluginsData[PLUGIN_NAME] && pluginsData[PLUGIN_NAME].config;
+    return kinveyNativeScriptSdkData;
+  } catch (err) {
+    return null;
+  }
+}
 
 export function init(config = <any>{}) {
+  const configFromPackageJson = getDataFromPackageJson() || <any>{};
+
+  config.appKey = config.appKey || configFromPackageJson.appKey;
+  config.appSecret = config.appSecret || configFromPackageJson.appSecret;
+  config.masterSecret = config.masterSecret || configFromPackageJson.masterSecret;
+
   if (!isDefined(config.appKey)) {
     throw new KinveyError('No App Key was provided.'
       + ' Unable to create a new Client without an App Key.');


### PR DESCRIPTION
#### Description
We are trying to create a convention for all NativeScript plugins to keep configuration data in `<project dir>/app/package.json`.
The values of the configuration data can be safely retrieved at runtime.
The idea of this PR is to read appKey, appSecret and masterSecret from this package.json file. The format there will be:
```JSON
{
	"android": {
		"v8Flags": "--expose_gc"
	},
	"main": "main.js",
	"name": "tns-template-hello-world-ng",
	"version": "3.1.1",
	"pluginsData": {
		"kinvey-nativescript-sdk": {
			"config": {
				"appKey": "app_key_value",
				"appSecret": "app_key_secret"
			}
		}
	}
}
```

This improves the logic on clients side - the init method can be called without arguments.
The other important improvement is that in Sidekick we can check if there are values for appKey and appSecret in this well known place and point the user to enter them in case they are missing. Also this allows us to easily change their values, i.e. support edit of values.

The current code change will allow the users to pass config to `Kinvey.init` method, so it is fully backwards compatible. However, in case some values are missing, we'll try to get them from package.json.

#### Changes
Allow Kinvey.init() in nativescript plugin to be called without arguments.
