### PR TITLE
MLIBZ-2399 clientid auth

### DIFF
--- a/src/core/identity/mic.js
+++ b/src/core/identity/mic.js
@@ -226,7 +226,7 @@ export class MobileIdentityConnect extends Identity {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      authType: AuthType.App,
+      authType: AuthType.Client,
       url: url.format({
         protocol: this.client.micProtocol,
         host: this.client.micHost,
@@ -238,7 +238,8 @@ export class MobileIdentityConnect extends Identity {
         client_id: clientId,
         redirect_uri: redirectUri,
         code: code
-      }
+      },
+      clientId: clientId
     });
     return request.execute().then(response => response.data);
   }
@@ -249,7 +250,7 @@ export class MobileIdentityConnect extends Identity {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      authType: AuthType.App,
+      authType: AuthType.Client,            
       url: url.format({
         protocol: this.client.micProtocol,
         host: this.client.micHost,
@@ -261,6 +262,7 @@ export class MobileIdentityConnect extends Identity {
         redirect_uri: redirectUri,
         refresh_token: token
       },
+      clientId: clientId,
       properties: options.properties,
       timeout: options.timeout
     });
@@ -268,23 +270,7 @@ export class MobileIdentityConnect extends Identity {
   }
 
   logout(user, options = {}) {
-    const request = new KinveyRequest({
-      method: RequestMethod.GET,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      authType: AuthType.App,
-      url: url.format({
-        protocol: this.client.micProtocol,
-        host: this.client.micHost,
-        pathname: '/oauth/invalidate',
-        query: {
-          user: user._id
-        }
-      }),
-      properties: options.properties
-    });
-    return request.execute().then(response => response.data);
+    return Promise.resolve();
   }
 
   /**

--- a/src/core/identity/mic.spec.js
+++ b/src/core/identity/mic.spec.js
@@ -204,6 +204,10 @@ describe('MobileIdentityConnect', () => {
             '/oauth/token',
             `grant_type=authorization_code&client_id=${client.appKey}&redirect_uri=${encodeURIComponent(redirectUri)}&code=${code}`
           )
+          .basicAuth({
+            user: client.appKey,
+            pass: client.appSecret
+          })
           .reply(200, token, {
             'Content-Type': 'application/json; charset=utf-8'
           });

--- a/src/core/identity/mic.spec.js
+++ b/src/core/identity/mic.spec.js
@@ -325,6 +325,10 @@ describe('MobileIdentityConnect', () => {
             '/oauth/token',
             `grant_type=authorization_code&client_id=${encodeURIComponent(client.appKey+'.'+micId)}&redirect_uri=${encodeURIComponent(redirectUri)}&code=${code}`
           )
+          .basicAuth({
+            user: client.appKey + '.' + micId,
+            pass: client.appSecret
+          })
           .reply(200, token, {
             'Content-Type': 'application/json; charset=utf-8'
           });

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -30,7 +30,8 @@ export const AuthType = {
   Default: 'Default',
   Master: 'Master',
   None: 'None',
-  Session: 'Session'
+  Session: 'Session',
+  Client: 'Client'
 };
 Object.freeze(AuthType);
 
@@ -74,6 +75,23 @@ const Auth = {
   basic(client) {
     return Auth.master(client)
       .catch(() => Auth.app(client));
+  },
+
+  client(client, clientId) {    
+    if (!client.appKey || !client.appSecret) {      
+      return Promise.reject(
+        new Error('Missing client appKey and/or appSecret'
+          + ' Use Kinvey.initialize() to set the appKey and masterSecret for the client.')
+      );
+    }
+    if (!clientId){
+      clientId = client.appKey;
+    }
+    return Promise.resolve({
+      scheme: 'Basic',
+      username: clientId,
+      password: client.appSecret
+    });
   },
 
   /**
@@ -160,6 +178,7 @@ export class KinveyRequest extends NetworkRequest {
     this.properties = options.properties || new Properties();
     this.skipBL = options.skipBL === true;
     this.trace = options.trace === true;
+    this.clientId = options.clientId;
   }
 
   static execute(options, client, dataOnly = true) {
@@ -320,7 +339,7 @@ export class KinveyRequest extends NetworkRequest {
 
     // Add or remove the Authorization header
     if (this.authType) {
-      // Get the auth info based on the set AuthType
+      // Get the auth info based on the set AuthType      
       switch (this.authType) {
         case AuthType.All:
           promise = Auth.all(this.client);
@@ -330,6 +349,9 @@ export class KinveyRequest extends NetworkRequest {
           break;
         case AuthType.Basic:
           promise = Auth.basic(this.client);
+          break;
+        case AuthType.Client:
+          promise = Auth.client(this.client, this.clientId);
           break;
         case AuthType.Master:
           promise = Auth.master(this.client);

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -81,7 +81,7 @@ const Auth = {
     if (!client.appKey || !client.appSecret) {      
       return Promise.reject(
         new Error('Missing client appKey and/or appSecret'
-          + ' Use Kinvey.initialize() to set the appKey and masterSecret for the client.')
+          + ' Use Kinvey.initialize() to set the appKey and appSecret for the client.')
       );
     }
     if (!clientId){


### PR DESCRIPTION
#### Description
Use the long form MIC `clientID` in the auth header for KAS endpoints

#### Changes
New `AuthType` called `Client` that uses the long-form MIC `clientID`.

#### Tests
Updated unit tests
