### PR TITLE
Fix Mobile Identity Connect Popup Issues

### DIFF
--- a/src/core/identity/mic.js
+++ b/src/core/identity/mic.js
@@ -46,7 +46,7 @@ export class MobileIdentityConnect extends Identity {
     if (options.version) {
       version = options.version;
     }
-    
+
     if (isString(version) === false) {
       version = String(version);
     }
@@ -125,6 +125,7 @@ export class MobileIdentityConnect extends Identity {
 
   requestCodeWithPopup(clientId, redirectUri, options = {}) {
     const promise = Promise.resolve().then(() => {
+      const popup = new Popup();
       return popup.open(url.format({
         protocol: this.client.micProtocol,
         host: this.client.micHost,

--- a/src/phonegap/popup.js
+++ b/src/phonegap/popup.js
@@ -93,7 +93,7 @@ export class Popup extends HTML5Popup {
   }
 
   static open(url) {
-    const popup = new PhoneGapPopup();
+    const popup = new Popup();
     return popup.open(url);
   }
 }

--- a/src/phonegap/popup.js
+++ b/src/phonegap/popup.js
@@ -1,7 +1,7 @@
-import { Popup } from '../html5/popup';
+import { Popup as HTML5Popup } from '../html5/popup';
 import { Device } from './device';
 
-export class PhoneGapPopup extends Popup {
+export class Popup extends HTML5Popup {
   open(url = '/') {
     const that = this;
 


### PR DESCRIPTION
#### Description
The Angular, Angular2, and PhoneGap SDKs all share the same popup class. All the imports expected an exported class named `Popup` but instead it was named `PhoneGapPopup`. This would cause a MIC to not work on environments using these SDKs.

#### Changes
- Rename `PhoneGapPopup` to `Popup`.
- Instantiante the `Popup` class when requesting a code for Mobile Identity Connect login.
