### PR TITLE
Beta release bugfixes

### DIFF
--- a/packages/kinvey-phonegap-sdk/src/bundle.js
+++ b/packages/kinvey-phonegap-sdk/src/bundle.js
@@ -4,9 +4,9 @@ import { MobileIdentityConnect } from '../../../src/core/identity';
 import { Popup } from '../../../src/phonegap/popup';
 import pkg from '../package.json';
 import '../../../src/html5/offline-data-storage';
-import { setPlatformConfig, platform } from '../../../src/core/platform-configs';
+import { setPlatformConfig, platformName } from '../../../src/core/platform-configs';
 
-setPlatformConfig(platform.phoneGap);
+setPlatformConfig(platformName.phoneGap);
 
 // Setup racks
 NetworkRack.useHttpMiddleware(new Html5HttpMiddleware(pkg));

--- a/src/core/datastore/cachestore.spec.js
+++ b/src/core/datastore/cachestore.spec.js
@@ -111,7 +111,7 @@ describe('CacheStore', () => {
         });
     });
 
-    it.skip('should return the entities', (done) => {
+    it('should return the entities', (done) => {
       const entity1 = { _id: randomString() };
       const entity2 = { _id: randomString() };
       const store = new CacheStore(collection);

--- a/src/core/datastore/persisters/memory-key-value-persister.js
+++ b/src/core/datastore/persisters/memory-key-value-persister.js
@@ -10,11 +10,12 @@ export class MemoryKeyValuePersister extends KeyValuePersister {
   }
 
   _readFromPersistance(key) {
-    return Promise.resolve(_storage[key]);
+    const result = _storage[key] || [];
+    return Promise.resolve(result.slice(0));
   }
 
   _writeToPersistance(key, array) {
-    _storage[key] = array;
+    _storage[key] = array.slice(0);
     return Promise.resolve(true);
   }
 

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -165,7 +165,7 @@ export class KinveyRequest extends NetworkRequest {
   static execute(options, client, dataOnly = true) {
     const o = assign({
       method: RequestMethod.GET,
-      authType: AuthType.Session
+      authType: AuthType.Default
     }, options);
     client = client || Client.sharedInstance();
 


### PR DESCRIPTION
#### Description
Fixes for MLIBZ-2398 and MLIBZ-2405. One was a typo, remaining from before the change in the name of the constant. The other was a suboptimal default value we used in the shorthand for executing an HTTP request. @thomasconner please confirm this is the way it should be used. It's overwritable, but I believe this should be the (aptly named) default always, no?

#### Changes
Fix name of "enum" for platform names. Use shallow copies of entities when using inmemory persistance. Change the default auth parameter of network request config.
