### PR TITLE
MLIBZ-2410 Expose data access classes from core SDK

### DIFF
--- a/packages/kinvey-js-sdk/src/index.js
+++ b/packages/kinvey-js-sdk/src/index.js
@@ -1,3 +1,3 @@
-export * from './bundle';
 import * as Kinvey from './bundle';
+export * from './bundle';
 export { Kinvey };

--- a/src/core/datastore/persisters/browser/browser-key-value-persister.js
+++ b/src/core/datastore/persisters/browser/browser-key-value-persister.js
@@ -41,11 +41,12 @@ export class BrowserKeyValuePersister extends KeyValuePersister {
     return Promise.resolve();
   }
 
-  // private methods
-
+  // this is now used in the ReactNative shim as a protected method
   _buildMasterCollectionName() {
     return `${Client.sharedInstance().appKey}.${browserStorageCollectionsMaster}`;
   }
+
+  // private methods
 
   _ensureCollectionExists(collection) {
     const masterCollectionName = this._buildMasterCollectionName();

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,4 +1,35 @@
 import './polyfills';
+
+import {
+  Repository,
+  NetworkRepository,
+  OfflineRepository,
+  InmemoryOfflineRepository,
+  KeyValueStoreOfflineRepository,
+  KeyValuePersister,
+  KeyValueStorePersister,
+  MemoryKeyValuePersister,
+  BrowserKeyValuePersister,
+  SqlKeyValueStorePersister,
+  IndexedDbKeyValueStorePersister,
+  repositoryProvider
+} from './datastore';
+
+export const DataAccess = {
+  Repository,
+  NetworkRepository,
+  OfflineRepository,
+  InmemoryOfflineRepository,
+  KeyValueStoreOfflineRepository,
+  KeyValuePersister,
+  KeyValueStorePersister,
+  MemoryKeyValuePersister,
+  BrowserKeyValuePersister,
+  SqlKeyValueStorePersister,
+  IndexedDbKeyValueStorePersister,
+  repositoryProvider
+};
+
 export { client, getAppVersion, setAppVersion, init, initialize, ping } from './kinvey';
 export { Acl } from './acl';
 export { Aggregation } from './aggregation';


### PR DESCRIPTION
#### Description
This exposes existing repositories, persisters and repositoryProvider from the core. They are not exposed in individual shims. These calsses are available under `Kinvey.DataAccess`. Input is welcome on this namespacing, as it seems classes usually were exposed directly on the Kinvey object. Also advice if this is the best way to expose those classes is also welcome, as I'm not too familiar with the practice here.

#### Changes
Classified `InmemoryOfflineRepository._delete()` and `BrowserKeyValuePersister._buildMasterCollectionName()` as "protected" from "private", as I have advised the guys from Dialexa to override these methods for their purposes and we should know this might break the RN shim, if changed (should they go that route).
