### PR TITLE
MLIBZ-2131 Remove implicit push() calls

### DIFF
--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -7,7 +7,7 @@ import { NetworkStore } from './networkstore';
 import { OperationType } from './operations';
 import { processorFactory } from './processors';
 import { syncManagerProvider } from './sync';
-import { formTaggedCollectionName } from './utils';
+import { formTaggedCollectionName, getEntitiesPendingPushError } from './utils';
 
 /**
  * The CacheStore class is used to find, create, update, remove, count and group entities. Entities are stored
@@ -114,7 +114,8 @@ export class CacheStore extends NetworkStore {
     return this.syncManager.getSyncItemCountByEntityQuery(this.collection, query)
       .then((count) => {
         if (count > 0) {
-          return this.syncManager.push(this.collection, query);
+          const err = getEntitiesPendingPushError(count, 'fetch the entities');
+          return Promise.reject(err);
         }
         return Promise.resolve();
       })

--- a/src/core/datastore/cachestore.spec.js
+++ b/src/core/datastore/cachestore.spec.js
@@ -397,28 +397,6 @@ describe('CacheStore', () => {
         });
     });
 
-    it('should throw an error if there are entities to sync', (done) => {
-      const entity = { _id: randomString() };
-      const syncStore = new SyncStore(collection);
-      syncStore.save(entity)
-        .then(() => {
-          const aggregation = new Aggregation();
-          const store = new CacheStore(collection);
-          store.group(aggregation)
-            .subscribe(null, (error) => {
-              try {
-                expect(error).toBeA(KinveyError);
-                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            }, () => {
-              done(new Error('This test should fail.'));
-            });
-        });
-    });
-
     it('should return the count of all unique properties on the collection', (done) => {
       const entity1 = { _id: randomString(), title: randomString() };
       const entity2 = { _id: randomString(), title: randomString() };
@@ -486,27 +464,6 @@ describe('CacheStore', () => {
           }
         }, () => {
           done(new Error('This test should fail.'));
-        });
-    });
-
-    it('should throw an error if there are entities to sync', (done) => {
-      const entity = { _id: randomString() };
-      const syncStore = new SyncStore(collection);
-      syncStore.save(entity)
-        .then(() => {
-          const store = new CacheStore(collection);
-          store.count()
-            .subscribe(null, (error) => {
-              try {
-                expect(error).toBeA(KinveyError);
-                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
-                done();
-              } catch (e) {
-                done(e);
-              }
-            }, () => {
-              done(new Error('This test should fail.'));
-            });
         });
     });
 

--- a/src/core/datastore/cachestore.spec.js
+++ b/src/core/datastore/cachestore.spec.js
@@ -13,7 +13,7 @@ import { NodeHttpMiddleware } from '../../node/http';
 import { User } from '../user';
 
 const collection = 'Books';
-const pendingPushEntitiesErrMsg = 'There are 1 entities, matching this query or id, pending push to the backend.';
+const pendingPushEntitiesErrMsg = 'There is 1 entity, matching the provided query or id, pending push to the backend.';
 
 describe('CacheStore', () => {
   let client;

--- a/src/core/datastore/cachestore.spec.js
+++ b/src/core/datastore/cachestore.spec.js
@@ -13,6 +13,7 @@ import { NodeHttpMiddleware } from '../../node/http';
 import { User } from '../user';
 
 const collection = 'Books';
+const pendingPushEntitiesErrMsg = 'There are 1 entities, matching this query or id, pending push to the backend.';
 
 describe('CacheStore', () => {
   let client;
@@ -97,10 +98,7 @@ describe('CacheStore', () => {
             .subscribe(null, (error) => {
               try {
                 expect(error).toBeA(KinveyError);
-                expect(error.message).toEqual(
-                  'Unable to fetch the entities on the backend.'
-                  + ' There are 1 entities that need to be synced.'
-                );
+                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
                 done();
               } catch (e) {
                 done(e);
@@ -263,10 +261,7 @@ describe('CacheStore', () => {
             .subscribe(null, (error) => {
               try {
                 expect(error).toBeA(KinveyError);
-                expect(error.message).toEqual(
-                  'Unable to find the entity on the backend.'
-                  + ' There are 1 entities that need to be synced.'
-                );
+                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
                 done();
               } catch (e) {
                 done(e);
@@ -413,10 +408,7 @@ describe('CacheStore', () => {
             .subscribe(null, (error) => {
               try {
                 expect(error).toBeA(KinveyError);
-                expect(error.message).toEqual(
-                  'Unable to group entities on the backend.'
-                  + ' There are 1 entities that need to be synced.'
-                );
+                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
                 done();
               } catch (e) {
                 done(e);
@@ -507,10 +499,7 @@ describe('CacheStore', () => {
             .subscribe(null, (error) => {
               try {
                 expect(error).toBeA(KinveyError);
-                expect(error.message).toEqual(
-                  'Unable to count entities on the backend.'
-                  + ' There are 1 entities that need to be synced.'
-                );
+                expect(error.message).toInclude(pendingPushEntitiesErrMsg);
                 done();
               } catch (e) {
                 done(e);

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -214,18 +214,12 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
   _ensureCountBeforeRead(collection, prefix, query) {
     return this._syncManager.getSyncItemCountByEntityQuery(collection, query)
       .then((count) => {
-        if (count > 0) { // backwards compatibility
-          return this._syncManager.push(collection, query)
-            .then(() => this._syncManager.getSyncItemCountByEntityQuery(collection, query));
-        }
-        return count;
-      })
-      .then((count) => {
         if (count === 0) {
           return count;
         }
-        const countMsg = `There are ${count} entities that need to be synced.`;
-        const err = new KinveyError(`Unable to ${prefix} on the backend. ${countMsg}`);
+        const countMsg = `There are ${count} entities, matching this query or id, pending push to the backend.`;
+        const errMsg = `Unable to ${prefix} on the backend, since the result might overwrite your local changes. ${countMsg}`;
+        const err = new KinveyError(errMsg);
         return Promise.reject(err);
       });
   }

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -128,12 +128,9 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
       return super._processCount(collection, query, options)
         .then((offlineCount) => {
           observer.next(offlineCount);
-          return this._ensureCountBeforeRead(collection, 'count entities', query);
+          return this._networkRepository.count(collection, query, options);
         })
-        .then(() => this._networkRepository.count(collection, query, options))
-        .then((networkCount) => {
-          observer.next(networkCount);
-        });
+        .then(networkCount => observer.next(networkCount));
     });
   }
 
@@ -143,9 +140,8 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
         .catch(() => []) // backwards compatibility
         .then((offlineResult) => {
           observer.next(offlineResult);
-          return this._ensureCountBeforeRead(collection, 'group entities');
+          return this._networkRepository.group(collection, aggregationQuery, options);
         })
-        .then(() => this._networkRepository.group(collection, aggregationQuery, options))
         .then(networkResult => observer.next(networkResult));
     });
   }

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -2,7 +2,7 @@ import { Promise } from 'es6-promise';
 import clone from 'lodash/clone';
 
 import { Query } from '../../query';
-import { KinveyError, NotFoundError } from '../../errors';
+import { NotFoundError } from '../../errors';
 
 import { OfflineDataProcessor } from './offline-data-processor';
 import { ensureArray } from '../../utils';

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -7,7 +7,7 @@ import { KinveyError, NotFoundError } from '../../errors';
 import { OfflineDataProcessor } from './offline-data-processor';
 import { ensureArray } from '../../utils';
 import { wrapInObservable } from '../../observable';
-import { isLocalEntity, isNotEmpty, isEmpty } from '../utils';
+import { isLocalEntity, isNotEmpty, isEmpty, getEntitiesPendingPushError } from '../utils';
 
 // imported for type info
 // import { NetworkRepository } from '../repositories';
@@ -217,10 +217,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
         if (count === 0) {
           return count;
         }
-        const countMsg = `There are ${count} entities, matching this query or id, pending push to the backend.`;
-        const errMsg = `Unable to ${prefix} on the backend, since the result might overwrite your local changes. ${countMsg}`;
-        const err = new KinveyError(errMsg);
-        return Promise.reject(err);
+        return Promise.reject(getEntitiesPendingPushError(count, prefix));
       });
   }
 

--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -79,13 +79,13 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
   _processRead(collection, query, options) {
     let offlineEntities;
     return wrapInObservable((observer) => {
-      return this._ensureCountBeforeRead(collection, 'fetch the entities', query)
-        .then(() => super._processRead(collection, query, options))
+      return super._processRead(collection, query, options)
         .then((entities) => {
           offlineEntities = entities;
           observer.next(offlineEntities);
-          return this._networkRepository.read(collection, query, options);
+          return this._ensureCountBeforeRead(collection, 'fetch the entities', query);
         })
+        .then(() => this._networkRepository.read(collection, query, options))
         .then((networkEntities) => {
           observer.next(networkEntities);
           return this._replaceOfflineEntities(collection, offlineEntities, networkEntities);
@@ -97,14 +97,14 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
     let offlineEntity;
     return wrapInObservable((observer) => {
       const query = new Query().equalTo('_id', entityId);
-      return this._ensureCountBeforeRead(collection, 'find the entity', query)
-        .then(() => super._processReadById(collection, entityId, options))
+      return super._processReadById(collection, entityId, options)
         .catch(err => this._catchNotFoundError(err)) // backwards compatibility
         .then((entity) => {
           observer.next(entity);
           offlineEntity = entity;
-          return this._networkRepository.readById(collection, entityId, options);
+          return this._ensureCountBeforeRead(collection, 'find the entity', query);
         })
+        .then(() => this._networkRepository.readById(collection, entityId, options))
         .then((entity) => {
           observer.next(entity);
           return this._replaceOfflineEntities(collection, offlineEntity, ensureArray(entity));
@@ -125,12 +125,12 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
 
   _processCount(collection, query, options) {
     return wrapInObservable((observer) => {
-      return this._ensureCountBeforeRead(collection, 'count entities', query)
-        .then(() => super._processCount(collection, query, options))
+      return super._processCount(collection, query, options)
         .then((offlineCount) => {
           observer.next(offlineCount);
-          return this._networkRepository.count(collection, query, options);
+          return this._ensureCountBeforeRead(collection, 'count entities', query);
         })
+        .then(() => this._networkRepository.count(collection, query, options))
         .then((networkCount) => {
           observer.next(networkCount);
         });

--- a/src/core/datastore/utils/utils.js
+++ b/src/core/datastore/utils/utils.js
@@ -6,8 +6,13 @@ import { isNonemptyString } from '../../utils';
 export const dataStoreTagSeparator = '.';
 
 export function getEntitiesPendingPushError(entityCount, prefix) {
-  const countMsg = `There are ${entityCount} entities, matching this query or id, pending push to the backend.`;
-  const errMsg = `Unable to ${prefix} on the backend, since the result might overwrite your local changes. ${countMsg}`;
+  let countMsg = `There are ${entityCount} entities, matching the provided query, pending push to the backend.`;
+
+  if (entityCount === 1) {
+    countMsg = `There is ${entityCount} entity, matching the provided query or id, pending push to the backend.`;
+  }
+
+  const errMsg = `Unable to ${prefix} on the backend. The result will overwrite your local changes. ${countMsg}`;
   return new KinveyError(errMsg);
 }
 

--- a/src/core/datastore/utils/utils.js
+++ b/src/core/datastore/utils/utils.js
@@ -1,8 +1,15 @@
 import _isEmpty from 'lodash/isEmpty';
 
+import { KinveyError } from '../../errors';
 import { isNonemptyString } from '../../utils';
 
 export const dataStoreTagSeparator = '.';
+
+export function getEntitiesPendingPushError(entityCount, prefix) {
+  const countMsg = `There are ${entityCount} entities, matching this query or id, pending push to the backend.`;
+  const errMsg = `Unable to ${prefix} on the backend, since the result might overwrite your local changes. ${countMsg}`;
+  return new KinveyError(errMsg);
+}
 
 export function generateEntityId(length = 24) {
   const chars = 'abcdef0123456789';

--- a/src/core/datastore/utils/utils.js
+++ b/src/core/datastore/utils/utils.js
@@ -6,13 +6,13 @@ import { isNonemptyString } from '../../utils';
 export const dataStoreTagSeparator = '.';
 
 export function getEntitiesPendingPushError(entityCount, prefix) {
-  let countMsg = `There are ${entityCount} entities, matching the provided query, pending push to the backend.`;
+  let countMsg = `are ${entityCount} entities, matching the provided query`;
 
   if (entityCount === 1) {
-    countMsg = `There is ${entityCount} entity, matching the provided query or id, pending push to the backend.`;
+    countMsg = `is ${entityCount} entity, matching the provided query or id`;
   }
 
-  const errMsg = `Unable to ${prefix} on the backend. The result will overwrite your local changes. ${countMsg}`;
+  const errMsg = `Unable to ${prefix} on the backend. There ${countMsg}, pending push to the backend. The result will overwrite your local changes.`;
   return new KinveyError(errMsg);
 }
 

--- a/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
+++ b/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
@@ -208,8 +208,6 @@ describe('CacheOfflineDataProcessor', () => {
           expect(result).toBeA(KinveyObservable);
         });
 
-        addSyncQueueTests();
-
         it('should call OfflineRepo.count()', () => {
           return dataProcessor.process(operation, options).toPromise()
             .then(() => {
@@ -241,8 +239,6 @@ describe('CacheOfflineDataProcessor', () => {
               validateSpyCalls(offlineRepoMock.group, 1, [collection, operation.query, options]);
             });
         });
-
-        addSyncQueueTests();
 
         it('should call NetworkRepo.group()', () => {
           return dataProcessor.process(operation, options).toPromise()

--- a/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
+++ b/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
@@ -75,48 +75,12 @@ describe('CacheOfflineDataProcessor', () => {
             });
         });
 
-        it('should call SyncManager.push() if there are entities to sync', () => {
+        it('should return an error if there are entities to sync', () => {
           syncManagerMock.getSyncItemCountByEntityQuery = createPromiseSpy(123);
-          syncManagerMock.push = createPromiseSpy().andCall(() => {
-            syncManagerMock.getSyncItemCountByEntityQuery = createPromiseSpy(0);
-            return Promise.resolve();
-          });
-          return dataProcessor.process(operation).toPromise()
-            .then(() => {
-              validateSpyCalls(syncManagerMock.push, 1, [collection, getExpectedQuery()]);
-            });
-        });
-
-        it('should call SyncManager.getSyncItemCountByEntityQuery() again, after push()', () => {
-          syncManagerMock.getSyncItemCountByEntityQuery = createPromiseSpy(123);
-          syncManagerMock.push = createPromiseSpy().andCall(() => {
-            syncManagerMock.getSyncItemCountByEntityQuery.andReturn(Promise.resolve(0));
-            return Promise.resolve();
-          });
-          return dataProcessor.process(operation).toPromise()
-            .then(() => {
-              validateSpyCalls(syncManagerMock.push, 1, [collection, getExpectedQuery()]);
-              const secondCountSpy = syncManagerMock.getSyncItemCountByEntityQuery;
-              validateSpyCalls(secondCountSpy, 2, [collection, getExpectedQuery()], [collection, getExpectedQuery()]);
-            });
-        });
-
-        it('should return an error if there are still entities to sync, after push()', () => {
-          syncManagerMock.getSyncItemCountByEntityQuery = createPromiseSpy(123);
-          syncManagerMock.push = createPromiseSpy().andCall(() => {
-            return Promise.resolve();
-          });
+          syncManagerMock.push = createPromiseSpy();
           return dataProcessor.process(operation).toPromise()
             .catch((err) => {
-              validateError(err, KinveyError, 'entities that need to be synced');
-            });
-        });
-
-        it('should NOT call SyncManager.push() if there are NO entities to sync', () => {
-          syncManagerMock.getSyncItemCountByEntityQuery = createPromiseSpy(0);
-          return dataProcessor.process(operation).toPromise()
-            .then(() => {
-              validateSpyCalls(syncManagerMock.push, 0);
+              validateError(err, KinveyError, 'pending push to the backend');
             });
         });
       }

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -424,12 +424,12 @@ function testFunc() {
               .catch(done);
           });
 
-          it('should make a silent push before the pull operation', (done) => {
+          it('should return an error if there are entities awaiting to be pushed to the backend', (done) => {
             syncStore.save(entity3)
               .then(() => storeToTest.pull())
-              .then(() => networkStore.findById(entity3._id).toPromise())
-              .then((result) => {
-                expect(result._id).to.equal(entity3._id);
+              .then(() => Promise.reject(new Error('should not happen')))
+              .catch((err) => {
+                expect(err.message).to.contain('There are 1 entities');
                 done();
               })
               .catch(done);

--- a/test/integration/tests/sync.test.js
+++ b/test/integration/tests/sync.test.js
@@ -429,7 +429,7 @@ function testFunc() {
               .then(() => storeToTest.pull())
               .then(() => Promise.reject(new Error('should not happen')))
               .catch((err) => {
-                expect(err.message).to.contain('There are 1 entities');
+                expect(err.message).to.contain('There is 1 entity');
                 done();
               })
               .catch(done);


### PR DESCRIPTION
#### Description
Remove the implicit push() calls in DataStore.pull(), CacheStore.find(), CacheStore.findById(), CacheStore.count(), CacheStore.group(). This removes potentially unexpected behaviour and improves the number of local reads from 2 to 4, to always 2.

#### Changes
Remove the count-push-count flow from CacheStore read-based ops. They do count and return an error if there are entities pending push. Otherwise proceed with their regular flow.

Put the check for entities pending push after the return of the offline result - it isn't being impeded by the entities pending sync.

Update tests accordingly.

Change the error message - input welcome.
