### PR TITLE
MLIBZ-2332: Add support for Instance ID

### DIFF
--- a/src/core/client.js
+++ b/src/core/client.js
@@ -54,8 +54,8 @@ export class Client {
    *
    * @param {Object}    options                                            Options
    * @param {string}    [options.instanceId='<my-subdomain>']              Custom subdomain for Kinvey API and MIC requests.
-   * @param {string}    [options.apiHostname='https://baas.kinvey.com']    Deprecated: Host name used for Kinvey API requests
-   * @param {string}    [options.micHostname='https://auth.kinvey.com']    Deprecated: Host name used for Kinvey MIC requests
+   * @param {string}    [options.apiHostname='https://baas.kinvey.com']    Deprecated: Use the instanceID property instead. Host name used for Kinvey API requests
+   * @param {string}    [options.micHostname='https://auth.kinvey.com']    Deprecated: Use the instanceID property instead. Host name used for Kinvey MIC requests
    * @param {string}    [options.appKey]                                   App Key
    * @param {string}    [options.appSecret]                                App Secret
    * @param {string}    [options.masterSecret]                             App Master Secret

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -53,8 +53,9 @@ export class Client {
    * Creates a new instance of the Client class.
    *
    * @param {Object}    options                                            Options
-   * @param {string}    [options.apiHostname='https://baas.kinvey.com']    Host name used for Kinvey API requests
-   * @param {string}    [options.micHostname='https://auth.kinvey.com']    Host name used for Kinvey MIC requests
+   * @param {string}    [options.instanceId='<my-subdomain>']              Custom subdomain for Kinvey API and MIC requests.
+   * @param {string}    [options.apiHostname='https://baas.kinvey.com']    Deprecated: Host name used for Kinvey API requests
+   * @param {string}    [options.micHostname='https://auth.kinvey.com']    Deprecated: Host name used for Kinvey MIC requests
    * @param {string}    [options.appKey]                                   App Key
    * @param {string}    [options.appSecret]                                App Secret
    * @param {string}    [options.masterSecret]                             App Master Secret
@@ -70,12 +71,30 @@ export class Client {
    */
 
   constructor(config = {}) {
-    let apiHostname = isString(config.apiHostname) ? config.apiHostname : 'https://baas.kinvey.com';
-    if (/^https?:\/\//i.test(apiHostname) === false) {
-      apiHostname = `https://${apiHostname}`;
+    let apiHostname = 'https://baas.kinvey.com';
+    let micHostname = 'https://auth.kinvey.com';
+
+    if (config.instanceId) {
+      const { instanceId } = config;
+
+      if (!isString(instanceId)) {
+        throw new KinveyError('Instance ID must be a string.');
+      }
+
+      apiHostname = `https://${instanceId}-baas.kinvey.com`;
+      micHostname = `https://${instanceId}-auth.kinvey.com`;
+    } else {
+      if (isString(config.apiHostname)) {
+        apiHostname = /^https?:\/\//i.test(config.apiHostname) ? config.apiHostname : `https://${config.apiHostname}`;
+      }
+
+      if (isString(config.micHostname)) {
+        micHostname = /^https?:\/\//i.test(config.micHostname) ? config.micHostname : `https://${config.micHostname}`;
+      }
     }
 
     const apiHostnameParsed = url.parse(apiHostname);
+    const micHostnameParsed = url.parse(micHostname);
 
     /**
      * @type {string}
@@ -91,13 +110,6 @@ export class Client {
      * @type {string}
      */
     this.apiHost = apiHostnameParsed.host;
-
-    let micHostname = isString(config.micHostname) ? config.micHostname : 'https://auth.kinvey.com';
-    if (/^https?:\/\//i.test(micHostname) === false) {
-      micHostname = `https://${micHostname}`;
-    }
-
-    const micHostnameParsed = url.parse(micHostname);
 
     /**
      * @type {string}

--- a/src/core/client.spec.js
+++ b/src/core/client.spec.js
@@ -12,6 +12,21 @@ describe('Client', () => {
       expect(client.micHostname).toEqual('https://auth.kinvey.com');
     });
 
+    it('should throw an error if instance id is not a string', () => {
+      expect(() => {
+        const instanceId = {};
+        const client = new Client({ instanceId });
+        return client;
+      }).toThrow(/Instance ID must be a string./);
+    });
+
+    it('should be able to provide an instance id', () => {
+      const instanceId = randomString().toLowerCase();
+      const client = new Client({ instanceId });
+      expect(client.apiHostname).toEqual(`https://${instanceId}-baas.kinvey.com`);
+      expect(client.micHostname).toEqual(`https://${instanceId}-auth.kinvey.com`);
+    });
+
     it('should be able to provide custom apiHostname with protocol https:', () => {
       const apiHostname = 'https://mybaas.kinvey.com';
       const client = new Client({ apiHostname: apiHostname });


### PR DESCRIPTION
#### Description
Allow a user to provide an`instanceId` config option to `init()` that will setup up the Kinvey API and MIC urls correctly.

```javascript
const client = init({
  appKey: '<appKey>',
  appSecret: '<appSecret>',
  instanceId: '<my-subdomain>'
});
client.apiHostname // https://<my-subdomain>-baas.kinvey.com
client.micHostname // https://<my-subdomain>-auth.kinvey.com
```

#### Changes
- Support config option `instanceId` in `client.js` constructor.

#### Tests
- Added a test to `client.spec.ts` that checks if an error is thrown if `instanceId` is anything but a string
- Added a test to `client.spec.ts` that checks if an `instanceId` is provided that the `apiHostname` and `micHostname` are correct.