### PR TITLE
MLIBZ-2393: Override exported Files module with NativeScript version

### DIFF
--- a/packages/kinvey-nativescript-sdk/src/bundle.ts
+++ b/packages/kinvey-nativescript-sdk/src/bundle.ts
@@ -26,7 +26,6 @@ export {
   DataStoreType,
   SyncOperation,
   LiveService,
-  Files,
   Log,
   Metadata,
   Query,

--- a/src/nativescript/index.ts
+++ b/src/nativescript/index.ts
@@ -7,3 +7,7 @@ export { Push } from './push';
 
 const supportedStorageProviders = repositoryProvider.getSupportedStorages();
 export const StorageProvider = pick(StorageProviderEnum, supportedStorageProviders);
+
+import { FileStore } from './filestore';
+const Files = new FileStore();
+export { Files };


### PR DESCRIPTION
#### Description
The NativeScript SDK overrides the `Files` module to upload files properly using native APIs for iOS and Android. The `Files` module needs to be exported in place of the `Files` module exported from the core to properly upload files using the NativeScript SDK.

#### Changes
- Export the `Files` module from the NativeScript SDK instead of the one from the core.

#### Tests
- Tested manually
