### PR TITLE
Add default entitlements plist file to nativescript sdk

### DIFF
--- a/packages/kinvey-nativescript-sdk/package.json
+++ b/packages/kinvey-nativescript-sdk/package.json
@@ -31,7 +31,8 @@
     "kinvey-nativescript-sdk.android.js.map",
     "kinvey.d.ts",
     "platforms/android/include.gradle",
-    "platforms/ios/Podfile"
+    "platforms/ios/Podfile",
+    "platforms/ios/app.entitlements"
   ],
   "nativescript": {
     "platforms": {

--- a/packages/kinvey-nativescript-sdk/platforms/ios/app.entitlements
+++ b/packages/kinvey-nativescript-sdk/platforms/ios/app.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
#### Description
Refer to https://github.com/Kinvey/nativescript-sdk/issues/31 for details on the issue and and proposed fix.

#### Changes
This PR adds a default `app.entitlements` file to the nativescript-sdk.

#### Tests
Tested manually with a MIC sample (https://github.com/tejasranade/EnterpriseSSO)