### PR TITLE
MLIBZ-2422: Validate MIC RedirectUri

### DIFF
--- a/src/core/identity/mic.js
+++ b/src/core/identity/mic.js
@@ -55,6 +55,10 @@ export class MobileIdentityConnect extends Identity {
   }
 
   login(redirectUri, authorizationGrant = AuthorizationGrant.AuthorizationCodeLoginPage, options = {}) {
+    if (!isString(redirectUri)) {
+      return Promise.reject(new KinveyError('A redirectUri is required and must be a string.'));
+    }
+
     let clientId = this.client.appKey;
 
     if (isString(options.micId)) {
@@ -206,7 +210,7 @@ export class MobileIdentityConnect extends Identity {
           password: options.password,
           scope: 'openid'
         },
-        followRedirect: false        
+        followRedirect: false
       });
       return request.execute();
     }).then((response) => {
@@ -253,7 +257,7 @@ export class MobileIdentityConnect extends Identity {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      authType: AuthType.Client,            
+      authType: AuthType.Client,
       url: url.format({
         protocol: this.client.micProtocol,
         host: this.client.micHost,

--- a/src/core/identity/mic.spec.js
+++ b/src/core/identity/mic.spec.js
@@ -4,7 +4,6 @@ import nock from 'nock';
 import url from 'url';
 import { MobileIdentityConnect, AuthorizationGrant } from './mic';
 import { InsufficientCredentialsError, MobileIdentityConnectError, KinveyError } from '../errors';
-import { Client } from '../client';
 import { randomString } from '../utils';
 import { NetworkRack } from '../request';
 import { NodeHttpMiddleware } from '../../node/http';
@@ -66,6 +65,36 @@ describe('MobileIdentityConnect', () => {
 
   describe('login()', () => {
     describe('AuthorizationGrant.AuthorizationCodeAPI', () => {
+      it('should fail if a redirect uri is not provided', () => {
+        const username = 'test';
+        const password = 'test';
+        const mic = new MobileIdentityConnect();
+        return mic.login(null, AuthorizationGrant.AuthorizationCodeAPI, { username, password })
+          .then(() => {
+            throw new Error('This test should fail');
+          })
+          .catch((error) => {
+            expect(error).toBeA(KinveyError);
+            expect(error.message).toEqual('A redirectUri is required and must be a string.');
+          });
+      });
+
+      it('should fail if redirect uri is not a string', () => {
+        it('should fail if a redirect uri is not provided', () => {
+          const username = 'test';
+          const password = 'test';
+          const mic = new MobileIdentityConnect();
+          return mic.login({}, AuthorizationGrant.AuthorizationCodeAPI, { username, password })
+            .then(() => {
+              throw new Error('This test should fail');
+            })
+            .catch((error) => {
+              expect(error).toBeA(KinveyError);
+              expect(error.message).toEqual('A redirectUri is required and must be a string.');
+            });
+        });
+      });
+
       it('should fail with invalid credentials', () => {
         const tempLoginUriParts = url.parse('https://auth.kinvey.com/oauth/authenticate/f2cb888e651f400e8c05f8da6160bf12');
         const username = 'test';


### PR DESCRIPTION
#### Description
Adds validation that checks if a `redirectUri` provided to `mic.login()` is provided and a string.

#### Changes
- Return a rejected `Promise` if the `redirectUri` provided to `mic.login()` is invalid.

#### Tests
- Added a test that checks that `mic.login()` fails when no `redirectUri` is provided.
- Added a test that checks that `mic.login()` fails when `redirectUri` is not a string.