### PR TITLE
Add push bundle for ios and android to files on package.json

### DIFF
--- a/packages/kinvey-nativescript-sdk/package.json
+++ b/packages/kinvey-nativescript-sdk/package.json
@@ -29,6 +29,8 @@
     "kinvey-nativescript-sdk.ios.js.map",
     "kinvey-nativescript-sdk.android.js",
     "kinvey-nativescript-sdk.android.js.map",
+    "push.android.js",
+    "push.ios.js",
     "kinvey.d.ts",
     "platforms/android/include.gradle",
     "platforms/ios/Podfile",


### PR DESCRIPTION
#### Description
The [kinvey-nativescript-sdk](https://www.npmjs.com/package/kinvey-nativescript-sdk) is missing the push bundled files when it is installed with NPM. This adds the push bundled files to the `package.json` files declaration to include them in the NPM package.

#### Changes
- Update `package.json` files for [kinvey-nativescript-sdk](https://www.npmjs.com/package/kinvey-nativescript-sdk)