### PR TITLE
MLIBZ-2517: Use correct query filter to delete multiple entities when using Server Side Delta Set

### DIFF
--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -131,7 +131,7 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
 
             if (data.deleted.length > 0) {
               const deleteQuery = new Query();
-              deleteQuery.containsAll('_id', data.deleted.map((entity) => entity._id));
+              deleteQuery.contains('_id', data.deleted.map((entity) => entity._id));
               promises.push(this._deleteEntitiesOffline(collection, deleteQuery, data.deleted));
             }
 

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -85,7 +85,7 @@ export class SyncManager {
             .then((data) => {
               if (data.deleted.length > 0) {
                 const deleteQuery = new Query();
-                deleteQuery.containsAll('_id', data.deleted.map((entity) => entity._id));
+                deleteQuery.contains('_id', data.deleted.map((entity) => entity._id));
                 return this._deleteOfflineEntities(collection, deleteQuery)
                   .then(() => data);
               }

--- a/test/integration/tests/delta-set.js
+++ b/test/integration/tests/delta-set.js
@@ -11,11 +11,11 @@ function testFunc() {
     const tagStore = 'kinveyTest';
 
     const validatePullOperation = (result, expectedItems, expectedPulledItemsCount, tagStore, collectionName) => {
-        const collectioNameForStore = collectionName?collectionName:deltaCollectionName;
-        const taggedDataStore = tagStore?Kinvey.DataStore.collection(deltaCollectionName, Kinvey.DataStoreType.Sync, { tag: tagStore }):null;
+        const collectioNameForStore = collectionName ? collectionName : deltaCollectionName;
+        const taggedDataStore = tagStore ? Kinvey.DataStore.collection(deltaCollectionName, Kinvey.DataStoreType.Sync, { tag: tagStore }) : null;
         const syncStoreToFind = Kinvey.DataStore.collection(collectioNameForStore, Kinvey.DataStoreType.Sync)
         expect(result).to.equal(expectedPulledItemsCount || expectedItems.length);
-        const storeToFind = tagStore ? taggedDataStore:syncStoreToFind;
+        const storeToFind = tagStore ? taggedDataStore : syncStoreToFind;
         return storeToFind.find().toPromise()
             .then((result) => {
                 expectedItems.forEach((entity) => {
@@ -97,11 +97,17 @@ function testFunc() {
                 });
 
                 it('should return correct number of items with created item', (done) => {
+                    const entity4 = utilities.getEntity(utilities.randomString());
+                    const entity5 = utilities.getEntity(utilities.randomString());
                     deltaStoreToTest.pull()
                         .then((result) => validatePullOperation(result, [entity1, entity2]))
                         .then(() => deltaNetworkStore.save(entity3))
                         .then(() => deltaStoreToTest.pull())
                         .then((result) => validateNewPullOperation(result, [entity3], []))
+                        .then(() => deltaNetworkStore.save(entity4))
+                        .then(() => deltaNetworkStore.save(entity5))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validateNewPullOperation(result, [entity4, entity5], []))
                         .then(() => done())
                         .catch(done);
                 });
@@ -169,36 +175,62 @@ function testFunc() {
                 });
 
                 it('should return correct number of items with deleted item', (done) => {
-                    deltaStoreToTest.pull()
-                        .then((result) => validatePullOperation(result, [entity1, entity2]))
-                        .then(() => deltaNetworkStore.removeById(entity2._id))
+                    deltaNetworkStore.save(entity3)
                         .then(() => deltaStoreToTest.pull())
-                        .then((result) => validateNewPullOperation(result, [], [entity2]))
+                        .then((result) => validatePullOperation(result, [entity1, entity2, entity3]))
+                        .then(() => deltaNetworkStore.removeById(entity1._id))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validateNewPullOperation(result, [], [entity1]))
+                        .then(() => deltaNetworkStore.removeById(entity2._id))
+                        .then(() => deltaNetworkStore.removeById(entity3._id))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validateNewPullOperation(result, [], [entity2, entity3]))
                         .then(() => done())
                         .catch(done);
                 });
 
                 it('should return correct number of items with updated item', (done) => {
                     const updatedEntity = _.clone(entity2);
+                    const updatedEntity1 = _.clone(entity1);
+                    const updatedEntity2 = _.clone(entity3);
                     updatedEntity.textField = utilities.randomString();
-                    deltaStoreToTest.pull()
-                        .then((result) => validatePullOperation(result, [entity1, entity2]))
+                    updatedEntity1.textField = utilities.randomString();
+                    updatedEntity2.textField = utilities.randomString();
+                    deltaNetworkStore.save(entity3)
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validatePullOperation(result, [entity1, entity2, entity3]))
                         .then(() => deltaNetworkStore.save(updatedEntity))
                         .then(() => deltaStoreToTest.pull())
                         .then((result) => validateNewPullOperation(result, [updatedEntity], []))
+                        .then(() => deltaNetworkStore.save(updatedEntity1))
+                        .then(() => deltaNetworkStore.save(updatedEntity2))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validateNewPullOperation(result, [updatedEntity1, updatedEntity2], []))
                         .then(() => done())
                         .catch(done);
                 });
 
                 it('should return correct number of items with updated and deleted item', (done) => {
+                    const entity4 = utilities.getEntity(utilities.randomString())
                     const updatedEntity = _.clone(entity2);
+                    const updatedEntity1 = _.clone(entity1);
+                    const updatedEntity2 = _.clone(entity3);
                     updatedEntity.textField = utilities.randomString();
-                    deltaStoreToTest.pull()
-                        .then((result) => validatePullOperation(result, [entity1, entity2]))
+                    updatedEntity1.textField = utilities.randomString();
+                    updatedEntity2.textField = utilities.randomString();
+                    deltaNetworkStore.save(entity3)
+                        .then(() => deltaNetworkStore.save(entity4))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validatePullOperation(result, [entity1, entity2, entity3, entity4]))
                         .then(() => deltaNetworkStore.save(updatedEntity))
                         .then(() => deltaNetworkStore.removeById(entity1._id))
                         .then(() => deltaStoreToTest.pull())
                         .then((result) => validateNewPullOperation(result, [updatedEntity], [entity1]))
+                        .then(() => deltaNetworkStore.save(updatedEntity2))
+                        .then(() => deltaNetworkStore.removeById(updatedEntity._id))
+                        .then(() => deltaNetworkStore.removeById(entity4._id))
+                        .then(() => deltaStoreToTest.pull())
+                        .then((result) => validateNewPullOperation(result, [updatedEntity2], [updatedEntity, entity4]))
                         .then(() => done())
                         .catch(done);
                 });
@@ -375,11 +407,17 @@ function testFunc() {
                 });
 
                 it('should return correct number of items with created item', (done) => {
+                    const entity4 = utilities.getEntity(utilities.randomString());
+                    const entity5 = utilities.getEntity(utilities.randomString());
                     deltaStoreToTest.sync()
                         .then((result) => validatePullOperation(result.pull, [entity1, entity2]))
                         .then(() => deltaNetworkStore.save(entity3))
                         .then(() => deltaStoreToTest.sync())
                         .then((result) => validateNewPullOperation(result.pull, [entity3], []))
+                        .then(() => deltaNetworkStore.save(entity4))
+                        .then(() => deltaNetworkStore.save(entity5))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validateNewPullOperation(result.pull, [entity4, entity5], []))
                         .then(() => done())
                         .catch(done);
                 });
@@ -448,36 +486,62 @@ function testFunc() {
                 });
 
                 it('should return correct number of items with deleted item', (done) => {
-                    deltaStoreToTest.sync()
-                        .then((result) => validatePullOperation(result.pull, [entity1, entity2]))
-                        .then(() => deltaNetworkStore.removeById(entity2._id))
+                    deltaNetworkStore.save(entity3)
                         .then(() => deltaStoreToTest.sync())
-                        .then((result) => validateNewPullOperation(result.pull, [], [entity2]))
+                        .then((result) => validatePullOperation(result.pull, [entity1, entity2, entity3]))
+                        .then(() => deltaNetworkStore.removeById(entity1._id))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validateNewPullOperation(result.pull, [], [entity1]))
+                        .then(() => deltaNetworkStore.removeById(entity2._id))
+                        .then(() => deltaNetworkStore.removeById(entity3._id))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validateNewPullOperation(result.pull, [], [entity2, entity3]))
                         .then(() => done())
                         .catch(done);
                 });
 
                 it('should return correct number of items with updated item', (done) => {
                     const updatedEntity = _.clone(entity2);
+                    const updatedEntity1 = _.clone(entity1);
+                    const updatedEntity2 = _.clone(entity3);
                     updatedEntity.textField = utilities.randomString();
-                    deltaStoreToTest.sync()
-                        .then((result) => validatePullOperation(result.pull, [entity1, entity2]))
+                    updatedEntity1.textField = utilities.randomString();
+                    updatedEntity2.textField = utilities.randomString();
+                    deltaNetworkStore.save(entity3)
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validatePullOperation(result.pull, [entity1, entity2, entity3]))
                         .then(() => deltaNetworkStore.save(updatedEntity))
                         .then(() => deltaStoreToTest.sync())
                         .then((result) => validateNewPullOperation(result.pull, [updatedEntity], []))
+                        .then(() => deltaNetworkStore.save(updatedEntity1))
+                        .then(() => deltaNetworkStore.save(updatedEntity2))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validateNewPullOperation(result.pull, [updatedEntity1, updatedEntity2], []))
                         .then(() => done())
                         .catch(done);
                 });
 
                 it('should return correct number of items with updated and deleted item', (done) => {
+                    const entity4 = utilities.getEntity(utilities.randomString())
                     const updatedEntity = _.clone(entity2);
+                    const updatedEntity1 = _.clone(entity1);
+                    const updatedEntity2 = _.clone(entity3);
                     updatedEntity.textField = utilities.randomString();
-                    deltaStoreToTest.sync()
-                        .then((result) => validatePullOperation(result.pull, [entity1, entity2]))
+                    updatedEntity1.textField = utilities.randomString();
+                    updatedEntity2.textField = utilities.randomString();
+                    deltaNetworkStore.save(entity3)
+                        .then(() => deltaNetworkStore.save(entity4))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validatePullOperation(result.pull, [entity1, entity2, entity3, entity4]))
                         .then(() => deltaNetworkStore.save(updatedEntity))
                         .then(() => deltaNetworkStore.removeById(entity1._id))
                         .then(() => deltaStoreToTest.sync())
                         .then((result) => validateNewPullOperation(result.pull, [updatedEntity], [entity1]))
+                        .then(() => deltaNetworkStore.save(updatedEntity2))
+                        .then(() => deltaNetworkStore.removeById(updatedEntity._id))
+                        .then(() => deltaNetworkStore.removeById(entity4._id))
+                        .then(() => deltaStoreToTest.sync())
+                        .then((result) => validateNewPullOperation(result.pull, [updatedEntity2], [updatedEntity, entity4]))
                         .then(() => done())
                         .catch(done);
                 });
@@ -721,17 +785,41 @@ function testFunc() {
 
                 it('should return correct number of items with deleted item', (done) => {
                     const onNextSpy = sinon.spy();
-                    deltaStoreToTest.find()
+                    deltaNetworkStore.save(entity3)
+                        .then(() => deltaStoreToTest.find()
                         .subscribe(onNextSpy, done, () => {
                             try {
-                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1], [entity1, entity2], true);
-                                const anotherSpy = sinon.spy();
+                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1], [entity1, entity2, entity3], true);
+                                onNextSpy.reset();
                                 deltaNetworkStore.removeById(entity1._id)
                                     .then(() => deltaStoreToTest.find()
-                                        .subscribe(anotherSpy, done, () => {
+                                        .subscribe(onNextSpy, done, () => {
                                             try {
-                                                utilities.validateReadResult(currentDataStoreType, anotherSpy, [entity1, entity2], [entity2], true);
-                                                done();
+                                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1, entity2, entity3], [entity2, entity3], true);
+                                                const secondSpy = sinon.spy();
+                                                deltaNetworkStore.removeById(entity2._id)
+                                                    .then(() => deltaNetworkStore.removeById(entity3._id))
+                                                    .then(() => deltaStoreToTest.find()
+                                                        .subscribe(secondSpy, done, () => {
+                                                            try {
+                                                                utilities.validateReadResult(currentDataStoreType, secondSpy, [entity2, entity3], [], true);
+                                                                onNextSpy.reset();
+                                                                syncStore.find()
+                                                                    .subscribe(onNextSpy, done, () => {
+                                                                        try {
+                                                                            utilities.validateReadResult(syncStore, onNextSpy, [])
+                                                                            done();
+                                                                        } catch (error) {
+                                                                            done(error)
+                                                                        }
+                                                                    })
+                                                            } catch (error) {
+                                                                done(error);
+                                                            }
+                                                        })
+                                                    )
+                                                    .catch(done);
+
                                             }
                                             catch (error) {
                                                 done(error);
@@ -741,7 +829,9 @@ function testFunc() {
                             catch (error) {
                                 done(error);
                             }
-                        });
+                        })
+                    )
+                    .catch(done);
                 });
 
                 it('should return correct number of items with updated item', (done) => {

--- a/test/integration/tests/delta-set.js
+++ b/test/integration/tests/delta-set.js
@@ -784,30 +784,32 @@ function testFunc() {
                 });
 
                 it('should return correct number of items with deleted item', (done) => {
+                    const entity4 = utilities.getEntity(utilities.randomString())
                     const onNextSpy = sinon.spy();
                     deltaNetworkStore.save(entity3)
+                        .then(() => deltaNetworkStore.save(entity4))
                         .then(() => deltaStoreToTest.find()
                         .subscribe(onNextSpy, done, () => {
                             try {
-                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1], [entity1, entity2, entity3], true);
+                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1], [entity1, entity2, entity3, entity4], true);
                                 onNextSpy.reset();
                                 deltaNetworkStore.removeById(entity1._id)
                                     .then(() => deltaStoreToTest.find()
                                         .subscribe(onNextSpy, done, () => {
                                             try {
-                                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1, entity2, entity3], [entity2, entity3], true);
+                                                utilities.validateReadResult(currentDataStoreType, onNextSpy, [entity1, entity2, entity3, entity4], [entity2, entity3, entity4], true);
                                                 const secondSpy = sinon.spy();
                                                 deltaNetworkStore.removeById(entity2._id)
                                                     .then(() => deltaNetworkStore.removeById(entity3._id))
                                                     .then(() => deltaStoreToTest.find()
                                                         .subscribe(secondSpy, done, () => {
                                                             try {
-                                                                utilities.validateReadResult(currentDataStoreType, secondSpy, [entity2, entity3], [], true);
+                                                                utilities.validateReadResult(currentDataStoreType, secondSpy, [entity2, entity3, entity4], [entity4], true);
                                                                 onNextSpy.reset();
                                                                 syncStore.find()
                                                                     .subscribe(onNextSpy, done, () => {
                                                                         try {
-                                                                            utilities.validateReadResult(syncStore, onNextSpy, [])
+                                                                            utilities.validateReadResult(Kinvey.DataStoreType.Sync, onNextSpy, [entity4])
                                                                             done();
                                                                         } catch (error) {
                                                                             done(error)


### PR DESCRIPTION
#### Steps to reproduce:
1. Enable deltaset
2. Create 5 items
3. Pull - there are now 5 items in cache
4. Delete 3 items
5. Pull - the request returns 3 items in deleted array
6. Check cached collection

#### Expected result
The 3 items deleted from the server are deleted in the cached collection.

#### Actual result: 
The items are still present in the cached collection.

#### Changes
- Use `contains()` instead of `containsAll()` for delete query
- Add integration test
