### PR TITLE
MLIBZ-2520: Delete items properly with Auto Pagination

### DIFF
--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -474,7 +474,7 @@ export class SyncManager {
       .then(({ lastRequest, count }) => {
         pullQuery = this._getInternalPullQuery(userQuery, count);
         return this._deleteOfflineEntities(collection)
-          .then(() => {@
+          .then(() => {
             const pageSizeSetting = options.autoPagination && options.autoPagination.pageSize;
             const pageSize = pageSizeSetting || maxEntityLimit;
             const paginatedQueries = splitQueryIntoPages(pullQuery, pageSize, count);

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -473,8 +473,8 @@ export class SyncManager {
     return this._getExpectedEntityCount(collection, userQuery)
       .then(({ lastRequest, count }) => {
         pullQuery = this._getInternalPullQuery(userQuery, count);
-        return this._deleteOfflineEntities(collection, pullQuery)
-          .then(() => {
+        return this._deleteOfflineEntities(collection)
+          .then(() => {@
             const pageSizeSetting = options.autoPagination && options.autoPagination.pageSize;
             const pageSize = pageSizeSetting || maxEntityLimit;
             const paginatedQueries = splitQueryIntoPages(pullQuery, pageSize, count);

--- a/src/core/datastore/working-with-data-tests/sync-manager.spec.js
+++ b/src/core/datastore/working-with-data-tests/sync-manager.spec.js
@@ -378,14 +378,11 @@ describe('SyncManager delegating to repos and SyncStateManager', () => {
           });
       });
 
-      it('should call OfflineRepo.delete() with the internal pull query', () => {
+      it('should call OfflineRepo.delete() without a query', () => {
         utilsMock.splitQueryIntoPages = expect.createSpy().andReturn([]);
         return syncManager.pull(collection, null, options)
           .then(() => {
-            const internalQueryMock = new Query();
-            internalQueryMock.limit = backendEntityCount;
-            internalQueryMock.sort = { [defaultSortField]: 1 };
-            validateSpyCalls(offlineRepoMock.delete, 1, [collection, internalQueryMock]);
+            validateSpyCalls(offlineRepoMock.delete, 1, [collection, undefined]);
           });
       });
 


### PR DESCRIPTION
#### Steps to reproduce:
1. Create a few items in the server and pull them locally
2. Enable auto-pagination
3. Delete a few items in the server 
4. Pull with auto-pagination

#### Expected result 
Items are deleted locally

#### Actual result 
Items are not deleted locally

#### Changes
- Remove all entities in the cache for a collection before loading pages using auto pagination

#### Tests
- Updated the existing unit test for this scenario
- Added an integration test for this scenario