### PR TITLE
MLIBZ-2503: User.me() does not delete newly-empty fields on the SDK

### DIFF
--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -137,6 +137,12 @@ const Auth = {
       );
     }
 
+    if (!isDefined(activeUser._kmd) || !isDefined(activeUser._kmd.authtoken)) {
+      return Promise.reject(
+        new NoActiveUserError('The active user does not have a valid auth token.')
+      );
+    }
+
     return Promise.resolve({
       scheme: 'Kinvey',
       credentials: activeUser._kmd.authtoken

--- a/src/core/user/user.js
+++ b/src/core/user/user.js
@@ -591,9 +591,6 @@ export class User {
     return request.execute()
       .then(response => response.data)
       .then((data) => {
-        // Merge returned data
-        data = assign(this.data, data);
-
         // Remove sensitive data
         delete data.password;
 


### PR DESCRIPTION
#### Steps to reproduce
1. Log into any web app using kinvey-html5-sdk
2. Check the value of a field in the current user's record to make sure it is non-empty – both in the Console -> Identity -> Users page, and in the client app.
3. In the Console -> Identity -> Users page, manually update/erase the value of the field.
4. In the client app, call user.me() on the current user - the saved active user in the SDK is not updated with the deleted property - the code here merges the updated fields but does not remove deleted properties.

#### Expected result
The field value should be empty/deleted from the current user's data in the client.

#### Actual result
The field value still exists that was empty/deleted.

#### Changes
- Remove merging of data returned in the response from the `/_me` endpoint. The active user data is now replaced with the data returned in the response from `/_me` endpoint.

#### Tests
- Remove irrelevant unit tests due to this change.
- Update an existing unit tests that checks that values are removed correctly.