### PR TITLE
MLIBZ-2455: TypeScript Definitions wrong for User.lookup()

### DIFF
--- a/src/kinvey.d.ts
+++ b/src/kinvey.d.ts
@@ -445,7 +445,7 @@ export namespace Kinvey {
     static verifyEmail(username: string, options?: RequestOptions): Promise<{}>;
     static forgotUsername(email: string, options?: RequestOptions): Promise<{}>;
     static resetPassword(username: string, options?: RequestOptions): Promise<{}>;
-    static lookup(query?: Query, options?: RequestOptions): Promise<{}>;
+    static lookup(query?: Query, options?: RequestOptions): Observable<{}>;
     static exists(username: string, options?: RequestOptions): Promise<{}>;
     static getActiveUser(client?: Client): User | null;
     static registerForLiveService(): Promise<void>;
@@ -961,7 +961,7 @@ export class User {
   static verifyEmail(username: string, options?: RequestOptions): Promise<{}>;
   static forgotUsername(email: string, options?: RequestOptions): Promise<{}>;
   static resetPassword(username: string, options?: RequestOptions): Promise<{}>;
-  static lookup(query?: Query, options?: RequestOptions): Promise<{}>;
+  static lookup(query?: Query, options?: RequestOptions): Observable<{}>;
   static exists(username: string, options?: RequestOptions): Promise<{}>;
   static getActiveUser(client?: Client): User | null;
   static registerForLiveService(): Promise<void>;


### PR DESCRIPTION
#### Description
The TypeScript definitions for `User.lookup()` function state that the function returns a `Promise` when it really returns an `Observable`.

#### Changes
- Update the TypeScript definitions file to state that the `User.lookup()` function returns an `Observable`.

#### Tests
- No testing needed. This was a documentation change.