### PR TITLE
MLIBZ-2526: Remove _kmd.local

### DIFF
--- a/src/core/datastore/sync.spec.js
+++ b/src/core/datastore/sync.spec.js
@@ -289,6 +289,24 @@ describe('Sync', () => {
       return store.clear();
     });
 
+    it('should remove _kmd.local for a locally created entity', async () => {
+      const entityId = randomString();
+      const store = new SyncStore(collection);
+      const entity = await store.save({});
+
+      const response = { _id: entityId };
+      nock(client.apiHostname)
+        .post(backendPathname, { _kmd: {} })
+        .reply(200, response);
+
+      const result = (await store.push()).shift();
+      expect(result).toEqual({
+        _id: entity._id,
+        operation: SyncOperation.Create,
+        entity: response
+      });
+    });
+
     it('should execute pending sync operations', () => {
       const entity1 = { _id: randomString() };
       const entity2 = { _id: randomString() };

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -236,6 +236,9 @@ export class SyncManager {
   _sanitizeOfflineEntity(offlineEntity) {
     const copy = clone(offlineEntity);
     delete copy._id;
+    if (copy._kmd) {
+      delete copy._kmd.local;
+    }
     return copy;
   }
 


### PR DESCRIPTION
#### Description
When an entity is created offline it will set the property `_kmd.local` to `true`. This needs to be removed before sending it to the backend. Currently it is not resulting in the following error:

```
{
  "error":"DataLinkConnectorError",
  "debug":"Unable to insert record. Error message = {\"_errors\":[{\"_errorMsg\":\"ERROR condition: An incomplete client request. (8020) (7211)\",\"_errorNum\":8020}]}",
  "description":"The DataLink request did not complete. See debug message for details."
}
```

#### Changes
- Remove `_kmd.local`

#### Tests
- Added unit test to verify `_kmd.local` is removed