### PR TITLE
MLIBZ-2575: Calculate file size

### DIFF
--- a/packages/kinvey-angular-sdk/src/bundle.js
+++ b/packages/kinvey-angular-sdk/src/bundle.js
@@ -25,7 +25,6 @@ export {
   DataStoreType,
   SyncOperation,
   LiveService,
-  Files,
   Log,
   Metadata,
   Query,

--- a/packages/kinvey-angular2-sdk/src/bundle.js
+++ b/packages/kinvey-angular2-sdk/src/bundle.js
@@ -25,7 +25,6 @@ export {
   DataStoreType,
   SyncOperation,
   LiveService,
-  Files,
   Log,
   Metadata,
   Query,

--- a/packages/kinvey-html5-sdk/src/bundle.js
+++ b/packages/kinvey-html5-sdk/src/bundle.js
@@ -26,7 +26,6 @@ export {
   DataStoreType,
   SyncOperation,
   LiveService,
-  Files,
   Log,
   Metadata,
   Query,

--- a/packages/kinvey-phonegap-sdk/src/bundle.js
+++ b/packages/kinvey-phonegap-sdk/src/bundle.js
@@ -27,7 +27,6 @@ export {
   DataStoreType,
   SyncOperation,
   LiveService,
-  Files,
   Log,
   Metadata,
   Query,

--- a/src/core/files.js
+++ b/src/core/files.js
@@ -288,6 +288,10 @@ export class FileStore {
    * @private
    */
   saveFileMetadata(options, metadata) {
+    if (metadata.size <= 0) {
+      return Promise.reject(new KinveyError('Unable to create a file with a size of 0.', metadata));
+    }
+
     const isUpdate = isDefined(metadata._id);
     const request = new KinveyRequest({
       method: isUpdate ? RequestMethod.PUT : RequestMethod.POST,

--- a/src/html5/files.js
+++ b/src/html5/files.js
@@ -1,0 +1,15 @@
+import { FileStore as CoreFilesStore } from '../core/files';
+import { KinveyError } from '../core/errors';
+
+export class FilesStore extends CoreFilesStore {
+  upload(file, metadata = {}, options) {
+    if (!(file instanceof global.Blob)) {
+      return Promise.reject(new KinveyError('File must be an instance of a Blob.'));
+    }
+
+    metadata.size = file.size;
+    return super.upload(file, metadata, options);
+  }
+}
+
+export const Files = new FilesStore();

--- a/src/html5/files.js
+++ b/src/html5/files.js
@@ -1,13 +1,14 @@
+import isString from 'lodash/isString';
 import { FileStore as CoreFilesStore } from '../core/files';
 import { KinveyError } from '../core/errors';
 
 export class FilesStore extends CoreFilesStore {
   upload(file, metadata = {}, options) {
-    if (!(file instanceof global.Blob)) {
-      return Promise.reject(new KinveyError('File must be an instance of a Blob.'));
+    if (!(file instanceof global.Blob) && !isString(file)) {
+      return Promise.reject(new KinveyError('File must be an instance of a Blob or the content of the file as a string.'));
     }
 
-    metadata.size = file.size;
+    metadata.size = file.size || file.length;
     return super.upload(file, metadata, options);
   }
 }

--- a/src/html5/index.js
+++ b/src/html5/index.js
@@ -3,6 +3,7 @@ import { StorageProvider as StorageProviderEnum, repositoryProvider } from '../c
 import './offline-data-storage';
 
 export * from './kinvey';
+export { Files } from './files';
 
 const supportedStorageProviders = repositoryProvider.getSupportedStorages();
 export const StorageProvider = pick(StorageProviderEnum, supportedStorageProviders);

--- a/src/nativescript/filestore/common.ts
+++ b/src/nativescript/filestore/common.ts
@@ -34,7 +34,7 @@ export class CommonFileStore extends CoreFileStore {
       return Promise.reject(new KinveyError('File does not exist'));
     }
 
-    metadata.size = metadata.size || this.getFileSize(filePath);
+    metadata.size = this.getFileSize(filePath);
     return super.upload(filePath, metadata, options);
   }
 

--- a/test/integration/tests/files-common.tests.js
+++ b/test/integration/tests/files-common.tests.js
@@ -351,22 +351,6 @@ function testFunc() {
         utilities.testFileUpload(fileToUpload1, metadata, metadata, fileContent1, undefined, done);
       })
 
-      it('should be able to upload if the submitted size is correct', (done) => {
-        const metadata = { size: fileContent1.length };
-        utilities.testFileUpload(fileToUpload1, metadata, metadata, fileContent1, undefined, done);
-      })
-
-      it('should return an error if the submitted size does not match the content length', (done) => {
-        const metadata = { size: fileContent1.length + 100 };
-        Kinvey.Files.upload(fileToUpload1, metadata)
-          .then(() => done(new Error(shouldNotBeCalledMessage)))
-          .catch((error) => {
-            expect(error).to.exist;
-            done();
-          })
-          .catch(done);
-      })
-
       it('should set _acl', (done) => {
         const randomId = utilities.randomString();
         const acl = new Kinvey.Acl({});


### PR DESCRIPTION
#### Description
To prevent errors the SDK should calculate the file size before it is uploaded. The file size should be then verified that we don't try and create a file with a size of 0.

#### Changes
- Calculate file size on HTML5. Export HTML5 FilesStore correctly.
- Verify file size before it is uploaded.

#### Tests
- _Add integration tests for related changes (TBD)_