### PR TITLE
MLIBZ-2580: Use correct Authorization header value for MIC refresh token request

### DIFF
--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -473,7 +473,7 @@ export class KinveyRequest extends NetworkRequest {
                 },
                 properties: this.properties,
                 timeout: this.timeout,
-                clientId: oldSession.clien_id
+                clientId: oldSession.client_id
               });
               return request.execute()
                 .then(response => response.data)

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -459,7 +459,7 @@ export class KinveyRequest extends NetworkRequest {
                 headers: {
                   'Content-Type': 'application/x-www-form-urlencoded'
                 },
-                authType: AuthType.App,
+                authType: AuthType.Client,
                 url: url.format({
                   protocol: this.client.micProtocol,
                   host: this.client.micHost,
@@ -472,7 +472,8 @@ export class KinveyRequest extends NetworkRequest {
                   refresh_token: oldSession.refresh_token
                 },
                 properties: this.properties,
-                timeout: this.timeout
+                timeout: this.timeout,
+                clientId: oldSession.clien_id
               });
               return request.execute()
                 .then(response => response.data)


### PR DESCRIPTION
#### Description
A MIC refresh token request is suppose to use the `clientId` value used to create the MIC session.

#### Changes
- Change auth type to `AuthType.Client` and pass `clientId` used to create MIC session