### PR TITLE
MLIBZ-2585: Queue requests when in the middle of refreshing a MIC access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7781,6 +7781,11 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "local-storage-fallback": "~4.0.0",
     "lodash": "~4.17.4",
     "loglevel": "~1.5.1",
+    "p-queue": "^2.4.2",
     "pubnub": "^4.19.0",
     "qs": "~6.5.1",
     "request": "~2.83.0",

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -546,10 +546,12 @@ export class KinveyRequest extends NetworkRequest {
                       return this.client.setActiveUser(user);
                     });
                 })
-                .catch(() => logout(this))
-                .then(() => {
-                  requestQueue.start();
-                  return Promise.reject(error);
+                .catch(() => {
+                  return logout(this)
+                    .then(() => {
+                      requestQueue.start();
+                      return Promise.reject(error);
+                    });
                 })
                 .then(() => {
                   requestQueue.start();

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -473,7 +473,7 @@ export class KinveyRequest extends NetworkRequest {
                 },
                 properties: this.properties,
                 timeout: this.timeout,
-                clientId: oldSession.clien_id
+                clientId: oldSession.client_id
               });
               return request.execute()
                 .then(response => response.data)


### PR DESCRIPTION
#### Description
A response to an API request can result in a `401` which will attempt to refresh a MIC access token. When multiple requests are made in parallel this would cause multiple attempts to refresh the MIC access token. This caused an invalid state that was unrecoverable.

This PR only allows one attempt to refresh a MIC access token while queuing up any other API request made while the refresh attempt is made. Once the refresh attempt completes then the queued requests will be retried.

#### Changes
- Queue up pending API requests when refreshing a MIC access token
