### PR TITLE
MLIBZ-2586: Use PubNub fork as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -8173,9 +8173,8 @@
       }
     },
     "pubnub": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/pubnub/-/pubnub-4.21.2.tgz",
-      "integrity": "sha512-yDDkqrvhFrBYFZsI4EL0Atnilo00OrRR+hCw86iTlkinMMxQbZhdn5yePrSc3GUs62kn3xDC6b73zaIKUYwWFg==",
+      "version": "github:thomasconner/javascript#4734baa41293422c38ee9808d37d1a394edbe894",
+      "from": "github:thomasconner/javascript",
       "requires": {
         "agentkeepalive": "^3.1.0",
         "lil-uuid": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "local-storage-fallback": "~4.0.0",
     "lodash": "~4.17.4",
     "loglevel": "~1.5.1",
-    "pubnub": "^4.19.0",
+    "pubnub": "github:thomasconner/javascript",
     "qs": "~6.5.1",
     "request": "~2.83.0",
     "rxjs": "~5.5.2",


### PR DESCRIPTION
#### Description
Setting the body for a `GET` request made with an Android app on [NativeScript](https://www.nativescript.org) results in the following error:

```
System.err: java.net.ProtocolException: method does not support a request body: GET
System.err:     at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:262)
System.err:     at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getOutputStream(DelegatingHttpsURLConnection.java:218)
System.err:     at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getOutputStream(Unknown Source:0)
System.err:     at org.nativescript.widgets.Async$Http$RequestOptions.writeContent(Async.java:313)
System.err:     at org.nativescript.widgets.Async$Http$HttpRequestTask.doInBackground(Async.java:536)
System.err:     at org.nativescript.widgets.Async$Http$1.run(Async.java:482)
System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
System.err:     at org.nativescript.widgets.Async$PriorityThreadFactory$1.run(Async.java:52)
System.err:     at java.lang.Thread.run(Thread.java:764)
```

This adds the [PubNub Fork](https://github.com/thomasconner/javascript) as a dependency to fix this issue.

#### Changes
- Update PubNub dependency
