### PR TITLE
MLIBZ-2604: Ignore query when executing push()

### DIFF
--- a/src/core/datastore/cachestore.js
+++ b/src/core/datastore/cachestore.js
@@ -90,15 +90,14 @@ export class CacheStore extends NetworkStore {
    * Push sync items for the data store to the network. A promise will be returned that will be
    * resolved with the result of the push or rejected with an error.
    *
-   * @param   {Query}                 [query]                                   Query to push a subset of items.
    * @param   {Object}                options                                   Options
    * @param   {Properties}            [options.properties]                      Custom properties to send with
    *                                                                            the request.
    * @param   {Number}                [options.timeout]                         Timeout for the request.
    * @return  {Promise}                                                         Promise
    */
-  push(query, options) {
-    return this.syncManager.push(this.collection, query, options);
+  push(options) {
+    return this.syncManager.push(this.collection, options);
   }
 
   /**
@@ -142,7 +141,7 @@ export class CacheStore extends NetworkStore {
   sync(query, options) {
     options = assign({ useDeltaSet: this.useDeltaSet }, options);
     const result = {};
-    return this.push(query, options)
+    return this.push(options)
       .then((pushResult) => {
         result.push = pushResult;
         return this.pull(query, options);

--- a/src/core/datastore/cachestore.spec.js
+++ b/src/core/datastore/cachestore.spec.js
@@ -1407,31 +1407,6 @@ describe('CacheStore', () => {
           expect(count).toEqual(0);
         });
     });
-
-    it('should push only the entities matching the query to the backend', () => {
-      const store = new CacheStore(collection);
-      const syncStore = new SyncStore(collection);
-      const entity1 = { _id: randomString() };
-      const entity2 = { _id: randomString() };
-
-      return syncStore.save(entity1)
-        .then(() => syncStore.save(entity2))
-        .then(() => {
-          nock(store.client.apiHostname)
-            .put(`${store.pathname}/${entity1._id}`, entity1)
-            .reply(200, entity1);
-
-          const query = new Query().equalTo('_id', entity1._id);
-          return store.push(query);
-        })
-        .then((result) => {
-          expect(result).toEqual([{ _id: entity1._id, operation: SyncOperation.Update, entity: entity1 }]);
-          return store.pendingSyncCount();
-        })
-        .then((count) => {
-          expect(count).toEqual(1);
-        });
-    });
   });
 
   describe('pull()', () => {

--- a/src/core/datastore/datastore.doc.js
+++ b/src/core/datastore/datastore.doc.js
@@ -141,14 +141,13 @@ export class DataStore {
   /**
    * Push pending sync items to the backend.
    *
-   * @param   {Query}                 [query]                                   Query to push a subset of items.
    * @param   {Object}                options                                   Options
    * @param   {Properties}            [options.properties]                      Custom properties to send with
    *                                                                            the request.
    * @param   {Number}                [options.timeout]                         Timeout for the request.
    * @return  {Promise}                                                         Push result
    */
-  push(query, options) {}
+  push(options) {}
 
   /**
    * Pull entities from the backend and save them to the local cache

--- a/src/core/datastore/sync/sync-manager.js
+++ b/src/core/datastore/sync/sync-manager.js
@@ -33,7 +33,7 @@ export class SyncManager {
     this._syncStateManager = syncStateManager;
   }
 
-  push(collection, query) {
+  push(collection) {
     if (isEmpty(collection) || !isNonemptyString(collection)) {
       return Promise.reject(new KinveyError('Invalid or missing collection name'));
     }
@@ -44,14 +44,8 @@ export class SyncManager {
     }
 
     this._markPushStart(collection);
-    let prm = Promise.resolve();
 
-    if (query) {
-      prm = this._getEntityIdsForQuery(collection, query);
-    }
-
-    return prm
-      .then((entityIds) => this._syncStateManager.getSyncItems(collection, entityIds))
+    return this._syncStateManager.getSyncItems(collection)
       .then((syncItems = []) => this._processSyncItems(collection, syncItems))
       .then((pushResult) => {
         this._markPushEnd(collection);

--- a/src/core/datastore/syncstore.spec.js
+++ b/src/core/datastore/syncstore.spec.js
@@ -776,32 +776,6 @@ describe('SyncStore', () => {
         });
     });
 
-    it('should push only the entities matching the query to the backend', () => {
-      const store = new SyncStore(collection);
-      const entity1 = { _id: randomString() };
-      const entity2 = { _id: randomString() };
-
-      return store.save(entity1)
-        .then(() => {
-          return store.save(entity2);
-        })
-        .then(() => {
-          nock(client.apiHostname)
-            .put(`/appdata/${client.appKey}/${collection}/${entity1._id}`, entity1)
-            .reply(200, entity1);
-
-          const query = new Query().equalTo('_id', entity1._id);
-          return store.push(query);
-        })
-        .then((result) => {
-          expect(result).toEqual([{ _id: entity1._id, operation: SyncOperation.Update, entity: entity1 }]);
-          return store.pendingSyncCount();
-        })
-        .then((count) => {
-          expect(count).toEqual(1);
-        });
-    });
-
     it('should push the entities by tag', () => {
       const entity1 = { _id: randomString() };
       const entity2 = { _id: randomString() };

--- a/src/core/datastore/working-with-data-tests/sync-manager.spec.js
+++ b/src/core/datastore/working-with-data-tests/sync-manager.spec.js
@@ -99,12 +99,11 @@ describe('SyncManager delegating to repos and SyncStateManager', () => {
     });
 
     it('should read the offline entities the query matches, to filter sync items', () => {
-      const query = new Query();
       const localEntitiesToReturn = [{ _id: '123' }];
       offlineRepoMock.read = createPromiseSpy(localEntitiesToReturn);
-      return syncManager.push(collection, query)
+      return syncManager.push(collection)
         .then(() => {
-          validateSpyCalls(offlineRepoMock.read, 1, [collection, query]);
+          validateSpyCalls(offlineRepoMock.read, 0, [collection]);
         });
     });
 
@@ -116,13 +115,12 @@ describe('SyncManager delegating to repos and SyncStateManager', () => {
     });
 
     it('should call SyncStateManager.getSyncItems() with the ids of entities matching the query', () => {
-      const query = new Query();
       const entityId = randomString();
       const localEntitiesToReturn = [{ _id: entityId }];
       offlineRepoMock.read = createPromiseSpy(localEntitiesToReturn);
-      return syncManager.push(collection, query)
+      return syncManager.push(collection)
         .then(() => {
-          validateSpyCalls(syncStateManagerMock.getSyncItems, 1, [collection, entityId]);
+          validateSpyCalls(syncStateManagerMock.getSyncItems, 1, [collection]);
         });
     });
 


### PR DESCRIPTION
#### Description
All items in the sync queue should be pushed to the backend when given the opportunity. A `query` should not be allowed to push a subset of the sync queue.

#### Changes
- Remove use of a `query` to push a subset of the sync queue.
- Update reference docs.

#### Tests
- Update related unit tests.
