### PR TITLE
MIBZ-2453: Kinvey.Files.downloadByUrl should call the error function if the server returns an error

### DIFF
--- a/src/html5/http.js
+++ b/src/html5/http.js
@@ -87,9 +87,12 @@ export class Html5HttpMiddleware extends Middleware {
         timeout,
         followRedirect
       } = request;
+      const kinveyUrlRegex = /kinvey\.com/gm;
 
-      // Add the X-Kinvey-Device-Information header
-      headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+      if (kinveyUrlRegex.test(url)) {
+        // Add the X-Kinvey-Device-Information header
+        headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+      }
 
       this.xhrRequest = xhr({
         method: method,
@@ -102,9 +105,11 @@ export class Html5HttpMiddleware extends Middleware {
         if (isDefined(error)) {
           if (error.code === 'ESOCKETTIMEDOUT' || error.code === 'ETIMEDOUT') {
             return reject(new TimeoutError('The network request timed out.'));
+          } else if (error.code === 'ENOENT') {
+            return reject(new NetworkConnectionError('You do not have a network connection.'));
           }
 
-          return reject(new NetworkConnectionError('There was an error connecting to the network.', error));
+          return reject(error);
         }
 
         return resolve({

--- a/src/nativescript/http.ts
+++ b/src/nativescript/http.ts
@@ -27,7 +27,13 @@ export class HttpMiddleware extends Middleware {
 
   handle(request: any): Promise<any> {
     const { url, method, headers, body, timeout, followRedirect } = request;
-    headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+    const kinveyUrlRegex = /kinvey\.com/gm;
+
+    if (kinveyUrlRegex.test(url)) {
+      // Add the X-Kinvey-Device-Information header
+      headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+    }
+
     const options = {
       method: method,
       headers: headers,

--- a/src/node/http.js
+++ b/src/node/http.js
@@ -2,7 +2,7 @@ import httpRequest from 'request';
 import Promise from 'es6-promise';
 import { Middleware } from '../core/request';
 import { isDefined } from '../core/utils';
-import { NoNetworkConnectionError, TimeoutError } from '../core/errors';
+import { NetworkConnectionError, TimeoutError } from '../core/errors';
 
 function deviceInformation(pkg) {
   const platform = process.title;
@@ -37,9 +37,12 @@ export class NodeHttpMiddleware extends Middleware {
         timeout,
         followRedirect
       } = request;
+      const kinveyUrlRegex = /kinvey\.com/gm;
 
-      // Add the X-Kinvey-Device-Information header
-      headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+      if (kinveyUrlRegex.test(url)) {
+        // Add the X-Kinvey-Device-Information header
+        headers['X-Kinvey-Device-Information'] = deviceInformation(this.pkg);
+      }
 
       httpRequest({
         method: method,
@@ -53,7 +56,7 @@ export class NodeHttpMiddleware extends Middleware {
           if (error.code === 'ESOCKETTIMEDOUT' || error.code === 'ETIMEDOUT') {
             return reject(new TimeoutError('The network request timed out.'));
           } else if (error.code === 'ENOENT') {
-            return reject(new NoNetworkConnectionError('You do not have a network connection.'));
+            return reject(new NetworkConnectionError('You do not have a network connection.'));
           }
 
           return reject(error);


### PR DESCRIPTION
#### Description
**Steps To Reproduce:**

1. Stream a file with ttl = 0: 
```js
Kinvey.Files.download(fileId, { stream: true, ttl: 0 });
```

2. Try to download the file using the expired `__downloadURL_`: 
```js
Kinvey.Files.downloadByUrl(result._downloadURL);
```

**Expected Result:** The error function is called with the error from the server.
**Actual Result:** The success function is called with a string, containing an XML from the server:

```xml
<?xml version='1.0' encoding='UTF-8'?><Error><Code>ExpiredToken</Code><Message>The provided token has expired.</Message><Details>Request has expired: 1523979099</Details></Error>
```

#### Changes
- Reject with error from Network response.
- Only send X-Kinvey-Device-Information header to a kinvey.com endpoint.
