### PR TITLE
MLIBZ-2498: Kinvey.Files.upload() returns an error if the submitted metadata = null

### DIFF
--- a/src/html5/files.js
+++ b/src/html5/files.js
@@ -8,7 +8,7 @@ export class FilesStore extends CoreFilesStore {
       return Promise.reject(new KinveyError('File must be an instance of a Blob or the content of the file as a string.'));
     }
 
-    metadata.size = file.size || file.length;
+    metadata = Object.assign({ size: file.size || file.length }, metadata);
     return super.upload(file, metadata, options);
   }
 }

--- a/src/nativescript/filestore/common.ts
+++ b/src/nativescript/filestore/common.ts
@@ -34,7 +34,7 @@ export class CommonFileStore extends CoreFileStore {
       return Promise.reject(new KinveyError('File does not exist'));
     }
 
-    metadata.size = this.getFileSize(filePath);
+    metadata = Object.assign({ size: this.getFileSize(filePath) }, metadata);
     return super.upload(filePath, metadata, options);
   }
 


### PR DESCRIPTION
#### Description
Tested with 3.10.3 in the HTML5 shim. The tests for upload in _test/integration/tests/files-common.tests.js_  in _QA-196_tests_files_ branch can be accommodated in order to reproduce the issue.

**Steps To Reproduce**:

1. Try to upload a file with:

```js
Kinvey.Files.upload(file, null, { timeout: 100000 })
```

**Expected Result:** The operation succeeds
**Actual Result:** The following error:

```js
TypeError: Cannot read property 'filename' of null
      at FileStore.transformMetadata (http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:33946:41)
      at FileStore.upload (http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:33894:23)
      at Object.testFileUpload (http://localhost:64320/test/integration/tests/utilities.js:252:18)
      at Context.it.only (http://localhost:64320/test/integration/tests/files-common.tests.js:349:19)
      at Test.Runnable.run (http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9439:29)
      at Runner.runTest (http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9854:22)
      at http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9900:26
      at next (http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9780:28)
      at http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9789:21
      at next (http://localhost:64320/node_modules/kinvey-universal-runner/injectables/bundles/testRunner.bundle.js:9733:35)
```

#### Changes
- Use `Object.assign()` to create metadata.