### PR TITLE
Update rxjs to version 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8695,11 +8695,11 @@
       }
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -9474,11 +9474,6 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -9833,8 +9828,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pubnub": "github:thomasconner/javascript",
     "qs": "~6.5.1",
     "request": "~2.83.0",
-    "rxjs": "~5.5.2",
+    "rxjs": "~6.2.2",
     "sift": "~5.0.0",
     "url-join": "~2.0.2",
     "xhr": "~2.4.0"

--- a/packages/kinvey-angular2-sdk/kinvey.d.ts
+++ b/packages/kinvey-angular2-sdk/kinvey.d.ts
@@ -3,7 +3,7 @@
 
 import {
   Observable
-} from 'rxjs/Observable';
+} from 'rxjs';
 
 export namespace Kinvey {
   export let appVersion: string;

--- a/packages/kinvey-nativescript-sdk/kinvey.d.ts
+++ b/packages/kinvey-nativescript-sdk/kinvey.d.ts
@@ -3,7 +3,7 @@
 
 import {
   Observable
-} from 'rxjs/Observable';
+} from 'rxjs';
 
 export namespace Kinvey {
   export let appVersion: string;

--- a/src/core/observable.js
+++ b/src/core/observable.js
@@ -1,7 +1,6 @@
 import Promise from 'es6-promise';
-import { Observable } from 'rxjs/Observable';
-import { Subscriber } from 'rxjs/Subscriber';
-import { rxSubscriber } from 'rxjs/symbol/rxSubscriber';
+import { Observable, Subscriber } from 'rxjs';
+import { rxSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
 import isFunction from 'lodash/isFunction';
 import { isDefined, isPromiseLike, wrapInPromise } from './utils';
 

--- a/src/core/utils/misc.js
+++ b/src/core/utils/misc.js
@@ -1,5 +1,5 @@
 import { Promise } from 'es6-promise';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 import isEmpty from 'lodash/isEmpty';
 import times from 'lodash/times';
 import isNumber from 'lodash/isNumber';


### PR DESCRIPTION
#### Description
This fixes #https://github.com/Kinvey/nativescript-sdk/issues/34.

#### Changes
- Update [rxjs](https://github.com/ReactiveX/rxjs) to version 6.