### PR TITLE
MLIBZ-2532: Missing instanceId in TypeScript definitions for Kinvey.init()

### DIFF
--- a/packages/kinvey-angular2-sdk/kinvey.d.ts
+++ b/packages/kinvey-angular2-sdk/kinvey.d.ts
@@ -30,6 +30,7 @@ export namespace Kinvey {
 
   // ClientConfig interface
   interface ClientConfig {
+    instanceId?: string;
     apiHostname?: string;
     micHostname?: string;
     appKey: string;
@@ -550,6 +551,7 @@ interface RequestOptions {
 
 // ClientConfig interface
 interface ClientConfig {
+  instanceId?: string;
   apiHostname?: string;
   micHostname?: string;
   appKey: string;

--- a/packages/kinvey-nativescript-sdk/kinvey.d.ts
+++ b/packages/kinvey-nativescript-sdk/kinvey.d.ts
@@ -30,6 +30,7 @@ export namespace Kinvey {
 
   // ClientConfig interface
   interface ClientConfig {
+    instanceId?: string;
     apiHostname?: string;
     micHostname?: string;
     appKey: string;
@@ -526,6 +527,7 @@ interface RequestOptions {
 
 // ClientConfig interface
 interface ClientConfig {
+  instanceId?: string;
   apiHostname?: string;
   micHostname?: string;
   appKey: string;


### PR DESCRIPTION
#### Description
The Typescript definitions for instanceId option is missing, resulting in error `"instanceId is not assignable to parameter of type clientConfig"`

#### Changes
- Added `instanceId?: string` to the TypeScript definitions