### PR TITLE
MLIBZ-2630: Not all entities returned from DataStore.find()

### DIFF
--- a/src/core/datastore/processors/cache-offline-data-processor.js
+++ b/src/core/datastore/processors/cache-offline-data-processor.js
@@ -125,7 +125,9 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
 
               return null;
             })
-            .then(() => response.data ? response.data : response);
+            .then(() => {
+              return response.data ? response.data : response;
+            });
         })
         .then((data) => {
           if (useDeltaSet) {
@@ -141,12 +143,13 @@ export class CacheOfflineDataProcessor extends OfflineDataProcessor {
               promises.push(this._replaceOfflineEntities(collection, data.changed, data.changed));
             }
 
-            return Promise.all(promises);
+            return Promise.all(promises)
+              .then(() => super._processRead(collection, query, options));
           }
 
-          return this._replaceOfflineEntities(collection, offlineEntities, data);
+          return this._replaceOfflineEntities(collection, offlineEntities, data)
+            .then(() => data);
         })
-        .then(() => super._processRead(collection, query, options))
         .then((entities) => {
           observer.next(entities);
           return entities;

--- a/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
+++ b/src/core/datastore/working-with-data-tests/cache-offline-data-processor.spec.js
@@ -100,7 +100,7 @@ describe('CacheOfflineDataProcessor', () => {
         it('should call OfflineRepo.read()', () => {
           return dataProcessor.process(operation, options).toPromise()
             .then(() => {
-              validateSpyCalls(offlineRepoMock.read, 2, [collection, operation.query, options], [collection, operation.query, options]);
+              validateSpyCalls(offlineRepoMock.read, 1, [collection, operation.query, options], [collection, operation.query, options]);
             });
         });
 


### PR DESCRIPTION
#### Description
Use `datastore.find()` to find entities on the backend that match a query. Make sure the entities returned don't contain all the matched properties in the query.

```json
[
    {
        "name": "John",
        "userId": "1"
     }
];
```

```javascript
const query = new Kinvey.Query();
query.equalTo('date', '7-25-2018');
query.equalTo('userId', '1');

const datastore = Kinvey.DataStore.collection('UserProfiles');
const entities = datastore.find(query);
// entities equals above json
```

#### Changes
- Return data from network call.

#### Tests
- Added test to check that data is still returned when the use case described above is encountered.