### PR TITLE
MLIBZ-2660: Fix iOS Push

### DIFF
--- a/packages/kinvey-nativescript-sdk/push.d.ts
+++ b/packages/kinvey-nativescript-sdk/push.d.ts
@@ -52,5 +52,5 @@ export class Push {
   static onNotification(listener: (notifaction: any) => void);
   static onceNotification(listener: (notifaction: any) => void);
   static register(options: PushOptions): Promise<string>;
-  static unregister(): Promise<null>;
+  static unregister(options: PushOptions): Promise<null>;
 }

--- a/packages/kinvey-nativescript-sdk/src/push/push.ios.ts
+++ b/packages/kinvey-nativescript-sdk/src/push/push.ios.ts
@@ -32,7 +32,7 @@ class IOSPush extends PushCommon {
       };
 
       PushPlugin.register(config, (token) => {
-        if (!config.interactiveSettings) {
+        if (config.interactiveSettings) {
           PushPlugin.registerUserNotificationSettings(() => {
             resolve(token);
           }, (error) => {


### PR DESCRIPTION
#### Changes
- Update TypeScript definitions for Push to allow options to be provided to `unregister()`
- Fix boolean logic for registering interactive settings for iOS push
