### PR TITLE
MLIBZ-2665: Send custom properties

### DIFF
--- a/src/core/datastore/repositories/network-repository.js
+++ b/src/core/datastore/repositories/network-repository.js
@@ -33,7 +33,7 @@ export class NetworkRepository extends Repository {
   }
 
   create(collection, entities, options) {
-    return this._processBatch(collection, RequestMethod.POST, entities, null, options);
+    return this._processBatch(collection, RequestMethod.POST, entities, options);
   }
 
   update(collection, entities, options) {


### PR DESCRIPTION
#### Description
Users are able to provide custom properties that are sent in the `x-kinvey-custom-request-properties` header.

#### Changes
- Fix order of arguments passed to function when creating an entity.
- Add unit tests for checking that the `x-kinvey-custom-request-properties` header is set
