### PR TITLE
MLIBZ-2543: Fix encoding issue when downloading files via the NativeScript SDK

### DIFF
--- a/src/core/files.js
+++ b/src/core/files.js
@@ -181,7 +181,8 @@ export class FileStore {
     const request = new NetworkRequest({
       method: RequestMethod.GET,
       url: url,
-      timeout: options.timeout
+      timeout: options.timeout,
+      file: true
     });
     return request.execute().then(response => response.data);
   }

--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -31,6 +31,13 @@ export class NetworkRequest extends Request {
   constructor(options = {}) {
     super(options);
     this.rack = NetworkRack;
+    this.file = options.file === true;
+  }
+
+  toPlainObject() {
+    return Object.assign(super.toPlainObject(), {
+      file: this.file
+    });
   }
 }
 

--- a/src/nativescript/http.ts
+++ b/src/nativescript/http.ts
@@ -74,11 +74,16 @@ export class HttpMiddleware extends Middleware {
     };
     return (HttpRequest(options) as any)
       .then((response) => {
+        const contentType = response.headers['content-type'] || response.headers['Content-Type'];
         let data = response.content.raw;
 
-        try {
-          data = response.content.toString();
-        } catch (e) {}
+        if (contentType) {
+          if (contentType.indexOf('application/json') === 0) {
+            try {
+              data = response.content.toString();
+            } catch (e) {}
+          }
+        }
 
         return {
           response: {

--- a/src/nativescript/http.ts
+++ b/src/nativescript/http.ts
@@ -55,7 +55,7 @@ export class HttpMiddleware extends Middleware {
   }
 
   handle(request: any): Promise<any> {
-    const { url, method, headers, body, timeout, followRedirect } = request;
+    const { url, method, headers, body, timeout, followRedirect, file } = request;
     const kinveyUrlRegex = /kinvey\.com/gm;
 
     if (kinveyUrlRegex.test(url)) {
@@ -74,15 +74,12 @@ export class HttpMiddleware extends Middleware {
     };
     return (HttpRequest(options) as any)
       .then((response) => {
-        const contentType = response.headers['content-type'] || response.headers['Content-Type'];
         let data = response.content.raw;
 
-        if (contentType) {
-          if (contentType.indexOf('application/json') === 0) {
-            try {
-              data = response.content.toString();
-            } catch (e) {}
-          }
+        if (!file) {
+          try {
+            data = response.content.toString();
+          } catch (e) {}
         }
 
         return {


### PR DESCRIPTION
#### Changes
- Do not call `toString()` on the response data for file downloads.
