### PR TITLE
MLIBZ-2671: Fix MIC on Microsoft Edge

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.11.7"
+  "version": "3.12.0"
 }

--- a/src/html5/popup.js
+++ b/src/html5/popup.js
@@ -17,7 +17,7 @@ export class Popup extends EventEmitter {
             this.emit('loadstart', event);
             this.emit('load', event);
           } catch (error) {
-            if (error.code !== global.DOMException.SECURITY_ERR) {
+            if (error.code !== global.DOMException.SECURITY_ERR && error.message.indexOf('Permission Denied') !== -1) {
               this.emit('error', error);
             }
           }

--- a/src/html5/popup.js
+++ b/src/html5/popup.js
@@ -17,7 +17,11 @@ export class Popup extends EventEmitter {
             this.emit('loadstart', event);
             this.emit('load', event);
           } catch (error) {
-            if (error.code !== global.DOMException.SECURITY_ERR && error.message.indexOf('Permission Denied') !== -1) {
+            if (
+              // Most browsers throw this error
+              error.code !== global.DOMException.SECURITY_ERR
+              // Microsoft Edge throws this error
+              && error.message.indexOf('Permission Denied') !== -1) {
               this.emit('error', error);
             }
           }


### PR DESCRIPTION
#### Description
`loginWithMIC()` uses a popup when on a web browser to display the identity providers login page. An interval is setup to poll this popup for url changes. Once the popup redirects after a successful login the interval will parse the code received from the redirect url and provide it to the SDK.

While the user is attempting to login, the url of the popup is on a different domain of the hosted application that initiated the login. This causes an error when checking the url of the popup that has to be handled and thrown out.

This change handles the error specific thrown by Microsoft Edge when trying to access the url for the popup.

#### Changes
- Handle the specific error thrown by Microsoft Edge for `loginWithMIC()`

#### Tests
- This was tested manually on Microsoft Edge running on a Windows 10 VM and Google Chrome. It is not possible at this time to automate this test. `loginWithMIC()` worked correctly after I made this change.