### PR TITLE
Remove use of tns-core-modules/connectivity

### DIFF
--- a/packages/kinvey-nativescript-sdk/platforms/android/AndroidManifest.default.xml
+++ b/packages/kinvey-nativescript-sdk/platforms/android/AndroidManifest.default.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
 	<application android:name="com.tns.NativeScriptApplication">
 		<activity android:name="com.tns.NativeScriptActivity">
 			<intent-filter>

--- a/src/nativescript/http.ts
+++ b/src/nativescript/http.ts
@@ -1,6 +1,5 @@
 import { request as HttpRequest } from 'tns-core-modules/http';
 import { device } from 'tns-core-modules/platform';
-import { getConnectionType, connectionType } from 'tns-core-modules/connectivity';
 import { Middleware } from '../core/request';
 
 function deviceInformation(pkg = <any>{}) {
@@ -19,20 +18,6 @@ function deviceInformation(pkg = <any>{}) {
 }
 
 function deviceInformation2(pkg = <any>{}) {
-  let networkCondition = 'none';
-
-  switch (getConnectionType()) {
-    case connectionType.mobile:
-      networkCondition = 'cellular';
-      break;
-    case connectionType.wifi:
-      networkCondition = 'wifi';
-      break;
-    default:
-      networkCondition = 'none';
-      break;
-  }
-
   return {
     hv: 1,
     md: device.model,
@@ -41,7 +26,6 @@ function deviceInformation2(pkg = <any>{}) {
     sdk: pkg.name,
     pv: device.sdkVersion,
     ty: device.deviceType,
-    nc: networkCondition,
     id: device.uuid
   };
 }


### PR DESCRIPTION
#### Description
For the new `X-Kinvey-Device-Info` header, we were using the `tns-core-modules/connectivity` module to gather the network connection info. On Android you need to add the `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />` to the `AndroidManifest.xml` otherwise an error is thrown.

I had added this permission but the error is still thrown occasionally. Since it is not critical I am removing the use of the module for now.

#### Changes
- Remove the use of  the `tns-core-modules/connectivity` module
- Remove `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />` from the `AndroidManifest.xml`