### PR TITLE
MLIBZ-2497: Return correct error message if Files.findById() is called without a file id

### DIFF
--- a/src/core/files.js
+++ b/src/core/files.js
@@ -132,7 +132,7 @@ export class FileStore {
 
     if (!isDefined(name)) {
       return Promise.reject(
-        new KinveyError('A valid id is required to find a file by id.');
+        new KinveyError('A valid id is required to find a file by id.')
       );
     }
 

--- a/src/core/files.js
+++ b/src/core/files.js
@@ -130,6 +130,12 @@ export class FileStore {
     options = assign({ tls: true }, options);
     const queryStringObject = { tls: options.tls === true };
 
+    if (!isDefined(name)) {
+      return Promise.reject(
+        new KinveyError('A valid id is required to find a file by id.');
+      );
+    }
+
     if (isNumber(options.ttl)) {
       queryStringObject.ttl_in_seconds = parseInt(options.ttl, 10);
     }


### PR DESCRIPTION
### Description
__Steps To Reproduce__:

1. Try to download a file with:

```javascript
Kinvey.Files.findById();
```



__Expected Result:__ A meaningful error message, explaining that the id is required. The same problem is valid for `Kinvey.Files.download()`


__Actual Result:__ The following error:

```
TypeError: Cannot read property 'mimeType' of undefined
      at http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:33816:33
      at tryCatch (http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:967:12)
      at invokeCallback (http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:982:13)
      at http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:728:16
      at MutationObserver.flush (http://localhost:64320/packages/kinvey-html5-sdk/dist/kinvey-html5-sdk.js:677:5)
```

### Changes
- Check for a valid id and throw an error message if one is not provided.
