### PR TITLE
MLIBZ-2690: Calling me() overrides the active user data for _socialIdentity

### DIFF
--- a/src/core/user/user.js
+++ b/src/core/user/user.js
@@ -596,6 +596,15 @@ export class User {
 
         // Store the active user
         if (this.isActive()) {
+          // Merge _socialIdentity metadata not returned from the /_me endpoint
+          if (this._socialIdentity) {
+            data._socialIdentity = data._socialIdentity || {};
+            data._socialIdentity = Object.keys(this._socialIdentity).reduce((_socialIdentity, identity) => {
+              _socialIdentity[identity] = Object.assign(_socialIdentity[identity], data._socialIdentity[identity]);
+              return _socialIdentity;
+            }, this._socialIdentity);
+          }
+
           return this.client.setActiveUser(data);
         }
 

--- a/src/core/user/user.spec.js
+++ b/src/core/user/user.spec.js
@@ -744,6 +744,14 @@ describe('User', () => {
   });
 
   describe('me()', () => {
+    beforeEach(() => {
+      return UserMock.logout();
+    });
+
+    beforeEach(() => {
+      return UserMock.login(randomString(), randomString());
+    });
+
     it('should refresh the users data', () => {
       const user = new User({ _id: randomString(), name: randomString() });
       const reply = {
@@ -798,6 +806,27 @@ describe('User', () => {
       return user.me()
         .then((user) => {
           expect(user.data).toEqual(User.getActiveUser().data);
+        });
+    });
+
+    it('should merge _socialIdentity metadata', async () => {
+      await UserMock.loginWithMIC(randomString())
+      const activeUser = User.getActiveUser();
+      const _socialIdentity = activeUser._socialIdentity;
+      const reply = {
+        _id: activeUser._id,
+        username: randomString()
+      };
+
+      // Kinvey API response
+      nock(activeUser.client.apiHostname)
+        .get(`${activeUser.pathname}/_me`)
+        .reply(200, reply);
+
+      return activeUser.me()
+        .then((user) => {
+          console.log(user.data);
+          expect(user._socialIdentity).toEqual(_socialIdentity);
         });
     });
 

--- a/src/core/user/utils.js
+++ b/src/core/user/utils.js
@@ -1,0 +1,9 @@
+export function mergeSocialIdentity(origSocialIdentity = {}, newSocialIdentity = {}) {
+  const _origSocialIdentity = JSON.parse(JSON.stringify(origSocialIdentity));
+  const _newSocialIdentity = JSON.parse(JSON.stringify(newSocialIdentity));
+  const result = Object.keys(_newSocialIdentity).reduce((socialIdentity, identity) => {
+    socialIdentity[identity] = Object.assign(_newSocialIdentity[identity], _origSocialIdentity[identity]);
+    return socialIdentity;
+  }, _newSocialIdentity);
+  return result;
+}


### PR DESCRIPTION
### Description
__Steps to reproduce:__

1. Login with MIC in an app2. Call `User.me()`

__Expected result:__ The result of `User.me()` does not override the `activeUser` metadata set when login

__Actual result:__ The result of `User.me()` overrides the `activeUser` metadata set when login

### Changes
- Merge `_socialIdentity` metadata when `User.me()` is called
- Added unit test
