### PR TITLE
MLIBZ-2656: Merge _socialIdentity property on user

### DIFF
--- a/src/core/user/utils.js
+++ b/src/core/user/utils.js
@@ -1,0 +1,9 @@
+export function mergeSocialIdentity(origSocialIdentity = {}, newSocialIdentity = {}) {
+  const _origSocialIdentity = JSON.parse(JSON.stringify(origSocialIdentity));
+  const _newSocialIdentity = JSON.parse(JSON.stringify(newSocialIdentity));
+  const result = Object.keys(_newSocialIdentity).reduce((socialIdentity, identity) => {
+    socialIdentity[identity] = Object.assign(_newSocialIdentity[identity], _origSocialIdentity[identity]);
+    return socialIdentity;
+  }, _newSocialIdentity);
+  return result;
+}


### PR DESCRIPTION
#### Description
Preserve the data stored in `_socialIdentity` on the device over what is returned when updating and calling the `/me` endpoint.

#### Changes
- Merge the `_socialIdentity` properly
- Add unit test that checks if the `_socialIdentity` is correct when updating a user
