### PR TITLE
Conform with NativeScript preview application

### DIFF
--- a/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
+++ b/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
@@ -1,3 +1,3 @@
 module.exports = function ($logger) {
-  $logger.warn("If you are using loginWithMIC ensure that you have nsplayresume:// as one of your Redirect URI's in order for Mobile Identity Connect login to work in the Preview app.");
+  $logger.warn("If you are using loginWithMIC() ensure that you have added nsplayresume:// as a Redirect URI to your Mobile Identity Connect configuration at https://console.kinvey.com in order for Mobile Identity Connect login to work in the Preview app.");
 };

--- a/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
+++ b/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
@@ -1,0 +1,3 @@
+module.exports = function ($logger) {
+  $logger.warn("If you are using loginWithMIC ensure that you have nsplay:// as one of your Redirect URI's in order for Mobile Identity Connect login to work in the Preview app.");
+};

--- a/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
+++ b/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
@@ -1,3 +1,3 @@
 module.exports = function ($logger) {
-  $logger.warn("If you are using loginWithMIC ensure that you have nsplay:// as one of your Redirect URI's in order for Mobile Identity Connect login to work in the Preview app.");
+  $logger.warn("If you are using loginWithMIC ensure that you have nsplayresume:// as one of your Redirect URI's in order for Mobile Identity Connect login to work in the Preview app.");
 };

--- a/packages/kinvey-nativescript-sdk/package.json
+++ b/packages/kinvey-nativescript-sdk/package.json
@@ -41,6 +41,7 @@
     "push.ios.js",
     "push.ios.js.map",
     "lib/before-checkForChanges.js",
+    "lib/before-preview-sync.js",
     "lib/postinstall.js",
     "lib/preuninstall.js",
     "platforms/android/AndroidManifest.default.xml",
@@ -54,6 +55,11 @@
       {
         "type": "before-checkForChanges",
         "script": "lib/before-checkForChanges.js",
+        "inject": true
+      },
+      {
+        "type": "before-preview-sync",
+        "script": "lib/before-preview-sync.js",
         "inject": true
       }
     ],

--- a/packages/kinvey-nativescript-sdk/platforms/android/AndroidManifest.default.xml
+++ b/packages/kinvey-nativescript-sdk/platforms/android/AndroidManifest.default.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:name="com.tns.NativeScriptApplication">
-		<activity android:name="com.tns.NativeScriptActivity">
+		<activity
+			android:name="com.tns.NativeScriptActivity"
+			android:launchMode="singleTask">
+
 			<intent-filter>
 				<data android:scheme="{redirectUriScheme}" />
 				<action android:name="android.intent.action.VIEW" />

--- a/src/nativescript/popup/popup.ios.ts
+++ b/src/nativescript/popup/popup.ios.ts
@@ -31,6 +31,7 @@ class SFSafariViewControllerDelegateImpl extends NSObject implements SFSafariVie
 
 export class Popup extends EventEmitter {
   private _open = false;
+  private _viewController = null;
 
   open(url = '/', options: PopupOptions = {}) {
     // Handle redirect uri
@@ -59,7 +60,13 @@ export class Popup extends EventEmitter {
 
     // Show the view controller
     const app = utils.ios.getter(UIApplication, UIApplication.sharedApplication);
-    app.keyWindow.rootViewController.presentViewControllerAnimatedCompletion(sfc, true, null);
+    this._viewController = app.keyWindow.rootViewController;
+    // Get the topmost view controller
+    while (this._viewController.presentedViewController) {
+      this._viewController = this._viewController.presentedViewController;
+    }
+
+    this._viewController.presentViewControllerAnimatedCompletion(sfc, true, null);
 
     // Set open to true
     this._open = true;
@@ -69,9 +76,8 @@ export class Popup extends EventEmitter {
   }
 
   close() {
-    if (this._open) {
-      const app = utils.ios.getter(UIApplication, UIApplication.sharedApplication);
-      app.keyWindow.rootViewController.dismissViewControllerAnimatedCompletion(true, null);
+    if (this._open && this._viewController) {
+      this._viewController.dismissViewControllerAnimatedCompletion(true, null);
     }
 
     return this;

--- a/src/nativescript/user.js
+++ b/src/nativescript/user.js
@@ -4,7 +4,7 @@ import * as app from "application";
 
 export class User extends CoreUser {
   loginWithMIC(redirectUri, authorizationGrant, options) {
-    redirectUri = isInsidePreviewApp() ? "nsplay://" : redirectUri;
+    redirectUri = isInsidePreviewApp() ? "nsplayresume://" : redirectUri;
     const config = getDataFromPackageJson();
     return super.loginWithMIC(redirectUri || config.redirectUri, authorizationGrant, options);
   }

--- a/src/nativescript/user.js
+++ b/src/nativescript/user.js
@@ -1,8 +1,10 @@
 import { User as CoreUser } from '../core/user';
 import { getDataFromPackageJson } from './utils';
+import * as app from "application";
 
 export class User extends CoreUser {
   loginWithMIC(redirectUri, authorizationGrant, options) {
+    redirectUri = isInsidePreviewApp() ? "nsplay://" : redirectUri;
     const config = getDataFromPackageJson();
     return super.loginWithMIC(redirectUri || config.redirectUri, authorizationGrant, options);
   }
@@ -10,5 +12,17 @@ export class User extends CoreUser {
   static loginWithMIC(redirectUri, authorizationGrant, options) {
     const user = new User();
     return user.loginWithMIC(redirectUri, authorizationGrant, options);
+  }
+}
+
+function isInsidePreviewApp() {
+  return getAppIdentifier() === "org.nativescript.preview";
+}
+
+function getAppIdentifier() {
+  if (app.android) {
+    return app.android.packageName;
+  } else if (app.ios) {
+    return NSBundle.mainBundle.bundleIdentifier;
   }
 }


### PR DESCRIPTION
Conform Kinvey-sdk with NativeScript preview application. 
MIC login improvements.

Includes:
* **Improvement** Add before-preview-sync hook  - this hook will fire whenever a user scans a QR code displayed in the console from a `tns preview` command. It will warn the user that their application might not work as expected in case they do not have the {N} Preview app uri scheme
* **Improvement** Implement preview app check - kinvey {N} sdk now detects at runtime whether running inside {N} Preview app. If this is the case disregard any arguments passed to `loginWithMIC` and use the preview app scheme `nsplayresume` instead 
* **Fix(iOS):** Visualize login page in topmost `UIViewController` - prior to this the login page was displayed on the root `UIViewController`. Whenever the root `UIViewController` was obscured (for example user has another `UIViewController`  on top of the root one - e.g. a modal dialog) the login page would not show at all. iOS does not permit displaying items on invisible `UIViewController`s.
* **Fix(Android):** Ensure main activity is `singleTask` - ensure the main activity's launchMode is set to `singleTask` (meaning there may exist only a single instance of said activity throughout the whole Android system). This is needed because without it behavior is as follows: User clicks `loginWithMIC`, a login page is displayed in Chrome, User logs in and is redirected back to the application where the whole activity is re-created. This leads to potential unwanted behavior because instead of the login just continuing normally it leads to re-creation of the whole application

Ping @thomasconner for review