### PR TITLE
New notification callback handler for easier developer usage

### DIFF
--- a/packages/kinvey-nativescript-sdk/platforms/android/include.gradle
+++ b/packages/kinvey-nativescript-sdk/platforms/android/include.gradle
@@ -1,11 +1,3 @@
-android {
-  productFlavors {
-    "kinveynativescriptsdk" {
-      dimension "kinveynativescriptsdk"
-    }
-  }
-}
-
 repositories {
   mavenCentral()
 }

--- a/packages/kinvey-nativescript-sdk/push.d.ts
+++ b/packages/kinvey-nativescript-sdk/push.d.ts
@@ -42,6 +42,7 @@ interface PushOptions {
     },
     notificationCallbackIOS?: (message: any) => void
   };
+  notificationCallback?: (message: any) => void;
 }
 
 // Push class

--- a/packages/kinvey-nativescript-sdk/src/push/push.android.ts
+++ b/packages/kinvey-nativescript-sdk/src/push/push.android.ts
@@ -1,4 +1,5 @@
 import { Promise } from 'es6-promise';
+import * as application from "tns-core-modules/application";
 import { KinveyError } from './kinvey-nativescript-sdk';
 import { PushCommon } from './common';
 import { PushConfig, AndroidPushConfig } from './';
@@ -12,6 +13,43 @@ try {
 }
 
 class AndroidPush extends PushCommon {
+
+  private notificationCallback: (message: any) => void;
+
+  constructor() {
+    super();
+
+    const callback = (args: application.ApplicationEventData) => {
+      if (args.android && typeof this.notificationCallback === 'function') {
+        const activity = args.android;
+        const intent = activity.getIntent();
+        const extras = intent.getExtras();
+
+        const message = {
+          foreground: false
+        };
+
+        if (extras) {
+          const iterator = extras.keySet().iterator();
+          while (iterator.hasNext()) {
+            const key = iterator.next();
+            // exclude a few properties FCM adds
+            if (key !== "from" && key !== "collapse_key" && !key.startsWith("google.")) {
+              message[key] = extras.get(key);
+            }
+          }
+        }
+
+        this.notificationCallback(message);
+      }
+    };
+
+    // let's make sure the callback isn't registered more than once
+    application.off(application.resumeEvent, callback);
+    application.on(application.resumeEvent, callback);
+  }
+
+  // private
   protected _registerWithPushPlugin(options = <PushConfig>{}): Promise<string> {
     const config = options.android || <AndroidPushConfig>{};
 
@@ -22,10 +60,18 @@ class AndroidPush extends PushCommon {
           + ' setting up your project.'));
       }
 
+      this.notificationCallback = options.notificationCallback;
       const usersNotificationCallback = config.notificationCallbackAndroid;
       config.notificationCallbackAndroid = (jsonDataString: string, fcmNotification) => {
         if (typeof usersNotificationCallback === 'function') {
           usersNotificationCallback(jsonDataString, fcmNotification);
+        }
+
+        if (typeof options.notificationCallback === 'function') {
+          const message = JSON.parse(jsonDataString); // note: this also includes the "foreground" boolean property
+          message.title = fcmNotification.getTitle();
+          message.body = fcmNotification.getBody();
+          options.notificationCallback(message);
         }
 
         (this as any).emit('notification', JSON.parse(jsonDataString));

--- a/packages/kinvey-nativescript-sdk/src/push/push.d.ts
+++ b/packages/kinvey-nativescript-sdk/src/push/push.d.ts
@@ -30,6 +30,7 @@ export interface PushConfig {
   android?: AndroidPushConfig;
   ios?: IOSPushConfig;
   timeout?: number;
+  notificationCallback?: (message: any) => void;
 }
 
 export namespace Push {

--- a/packages/kinvey-nativescript-sdk/src/push/push.ios.ts
+++ b/packages/kinvey-nativescript-sdk/src/push/push.ios.ts
@@ -28,6 +28,12 @@ class IOSPush extends PushCommon {
           usersNotificationCallback(message);
         }
 
+        if (typeof options.notificationCallback === 'function') {
+          // let's transform the "foreground" ("0" / "1") into a proper boolean value
+          message.foreground = message.foreground === "1";
+          options.notificationCallback(message);
+        }
+
         (this as any).emit('notification', message);
       };
 


### PR DESCRIPTION
#### Description
The notification callbacks on iOS and Android behave differently: iOS receives a JSON object and Android a data String and native Notification object. Furthermore, on Android the callback is not invoked when the app is not in the foreground (which is probably mostly the case). Developers are advised to create a `resumeEvent` listener and parse the launch Intent to get the Andoir background notification data.

To overcome this situation, I've added a new notification callback handler which has the same return object for both iOS and Android. For backward compatibility sake I've not touched the current iOS and Android specific callbacks, so users can migrate to new callback whenever they fancy. Fixes https://github.com/Kinvey/nativescript-sdk/issues/43.

#### Changes
- Added `notificationCallback` which is invoked in the foreground and background on both iOS and Android and receives a JSON object with at least `{foreground: boolean}` and any data which was part of the `data` object in the notification. So if a notification contains `{data: {foo: 10}}`, the callback object will at least contain `{forground: [true|false], foo: 10}`. It will also include the `title` and `body` values, except when the notification was received on Android while the app was not in the foreground (because that's not part of the received launch Intent).

- To make the `notificationCallback` "work" on Android while in the background, the plugin now listens to the `resumeEvent` and the Intent will be parsed to get any data sent with the notification.

- To make the `foreground` property consistent across both platforms, on iOS the `foreground: "1"` / `foreground: "0"` value is transformed into respectively `foreground: true` and `foreground: false`.

- Oh, and I've removed an obsolete bit from `include.gradle` (it's no longer required, since a few NativeScript major versions).

> Note: [the CONTRIBUTING guide](https://github.com/Kinvey/js-sdk/blob/master/CONTRIBUTING.md#contributing-code) mentions targeting PRs to `develop`, but there ain't such branch so I've used `master` ;)