### PR TITLE
MLIBZ-2706: Add validation for save(), create(), and update()

### DIFF
--- a/src/core/datastore/networkstore.js
+++ b/src/core/datastore/networkstore.js
@@ -183,9 +183,8 @@ export class NetworkStore {
    * @return  {Promise}                                                 Promise.
    */
   create(entity, options = {}) {
-    // TODO: decide on this behaviour
     if (!isDefined(entity)) {
-      return Promise.resolve(null);
+      return Promise.reject(new KinveyError('No entity was provided. Please provide an entity you would like to create.'));
     }
 
     if (isArray(entity)) {
@@ -211,7 +210,7 @@ export class NetworkStore {
    */
   update(entity, options = {}) {
     if (!isDefined(entity)) {
-      return Promise.resolve(null); // TODO: really?
+      return Promise.reject(new KinveyError('No entity was provided. Please provide an entity you would like to update.'));
     }
 
     if (isArray(entity)) {
@@ -240,6 +239,10 @@ export class NetworkStore {
    * @return  {Promise}                                                 Promise.
    */
   save(entity, options) {
+    if (!entity) {
+      return Promise.reject(new KinveyError('No entity was provided. Please provide an entity you would like to save.'));
+    }
+
     if (entity._id) {
       return this.update(entity, options);
     }

--- a/src/core/datastore/networkstore.spec.js
+++ b/src/core/datastore/networkstore.spec.js
@@ -282,6 +282,16 @@ describe('NetworkStore', () => {
   });
 
   describe('create()', () => {
+    it('should throw an error if an entity is not provided', () => {
+      const store = new NetworkStore(collection);
+      return store.create()
+        .then(() => Promise.reject(new Error('This should not happen')))
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+          expect(error.message).toEqual('No entity was provided. Please provide an entity you would like to create.');
+        });
+    });
+
     it('should throw an error if trying to create an array of entities', async () => {
       const store = new NetworkStore(collection);
       const entity1 = {
@@ -368,6 +378,16 @@ describe('NetworkStore', () => {
   });
 
   describe('update()', () => {
+    it('should throw an error if an entity is not provided', () => {
+      const store = new NetworkStore(collection);
+      return store.update()
+        .then(() => Promise.reject(new Error('This should not happen')))
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+          expect(error.message).toEqual('No entity was provided. Please provide an entity you would like to update.');
+        });
+    });
+
     it('should throw an error if trying to update an array of entities', async () => {
       const store = new NetworkStore(collection);
       const entity1 = {
@@ -440,6 +460,16 @@ describe('NetworkStore', () => {
   describe('save()', () => {
     afterEach(() => {
       expect.restoreSpies();
+    });
+
+    it('should throw an error if an entity is not provided', () => {
+      const store = new NetworkStore(collection);
+      return store.save()
+        .then(() => Promise.reject(new Error('This should not happen')))
+        .catch((error) => {
+          expect(error).toBeA(KinveyError);
+          expect(error.message).toEqual('No entity was provided. Please provide an entity you would like to save.');
+        });
     });
 
     it('should call create() for an entity that does not contain an _id', () => {


### PR DESCRIPTION
#### Description
If you call `collection.create()` or `collection.update()` without an entity it will return resolve with `null`.

If you call `collection save()` without an entity then a `TypeError: Cannot read property '_id' of undefined` is thrown.

#### Changes
- Add validation to throw an error whenever an entity is not provided to save(), create(), and update()
