### PR TITLE
MLIBZ-2708: Throw NoActiveUserError when no active user exists and me() is called

### DIFF
--- a/src/core/user/user.js
+++ b/src/core/user/user.js
@@ -6,7 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 import url from 'url';
 import { Client } from '../client';
 import { AuthType, RequestMethod, KinveyRequest } from '../request';
-import { KinveyError, NotFoundError, ActiveUserError } from '../errors';
+import { KinveyError, NotFoundError, ActiveUserError, NoActiveUserError } from '../errors';
 import { DataStore } from '../datastore';
 import { MobileIdentityConnect } from '../identity';
 import { Log } from '../log';
@@ -675,7 +675,7 @@ export class User {
       return activeUser.me(options);
     }
 
-    return Promise.resolve(null);
+    return Promise.reject(new NoActiveUserError());
   }
 
   /**

--- a/src/core/user/user.spec.js
+++ b/src/core/user/user.spec.js
@@ -7,7 +7,7 @@ import { Acl } from '../acl';
 import { Metadata } from '../metadata';
 import { User } from './user';
 import { randomString } from '../utils';
-import { ActiveUserError, InvalidCredentialsError, KinveyError } from '../errors';
+import { ActiveUserError, InvalidCredentialsError, KinveyError, NoActiveUserError } from '../errors';
 import { CacheStore, SyncStore } from '../datastore';
 import { Client } from '../client';
 import { Query } from '../query';
@@ -865,6 +865,17 @@ describe('User', () => {
     it('should fail for a user that is not active', () => {
       const user = new User();
       return chai.expect(user.me()).to.eventually.be.rejected;
+    });
+
+    it.only('should fail if there is no active user', () => {
+      return UserMock.logout()
+        .then(() => User.me())
+        .then(() => {
+          throw new Error('This should not fail');
+        })
+        .catch((error) => {
+          expect(error).toBeAn(NoActiveUserError);
+        });
     });
   });
 

--- a/src/core/user/user.spec.js
+++ b/src/core/user/user.spec.js
@@ -871,7 +871,7 @@ describe('User', () => {
       return UserMock.logout()
         .then(() => User.me())
         .then(() => {
-          throw new Error('This should not fail');
+          throw new Error('This test should not successfully resolve, it should throw an error.');
         })
         .catch((error) => {
           expect(error).toBeAn(NoActiveUserError);


### PR DESCRIPTION
#### Description
When `me()` is called and no active user exists `null` is returned and no `_me` request is sent instead of throwing a `NoActiveUserError`.

#### Changes
- Throw `NoActiveUserError` when no active user exists and `me()` is called
