### PR TITLE
Respect instanceId from package.json.

### DIFF
--- a/src/nativescript/kinvey.ts
+++ b/src/nativescript/kinvey.ts
@@ -15,6 +15,7 @@ export function init(config = <any>{}) {
   config.appKey = config.appKey || configFromPackageJson.appKey;
   config.appSecret = config.appSecret || configFromPackageJson.appSecret;
   config.masterSecret = config.masterSecret || configFromPackageJson.masterSecret;
+  config.instanceId = config.instanceId || configFromPackageJson.instanceId
 
   if (!isDefined(config.appKey)) {
     throw new KinveyError('No App Key was provided.'


### PR DESCRIPTION
The idea of this PR is to read `instanceId` from this package.json file.
In Kinvey Studio we can check if there is value for `instanceId` and if user has Single-Tenant Cloud Instance to enter the correct value.

ping @thomasconner 

