### PR TITLE
Fix documentation link in kinvey-nativescript-sdk README

### DIFF
--- a/packages/kinvey-nativescript-sdk/README.md
+++ b/packages/kinvey-nativescript-sdk/README.md
@@ -25,7 +25,7 @@ The Kinvey NativeScript SDK supports the following Mobile OS versions:
 
 ## Documentation
 
-For more detailed documentation, see [Kinvey DevCenter](http://devcenter.kinvey.com/angular).
+For more detailed documentation, see [Kinvey DevCenter](https://devcenter.kinvey.com/nativescript).
 
 ## License
 


### PR DESCRIPTION
Makes change related to https://github.com/Kinvey/nativescript-sdk/pull/46.