### PR TITLE
MLIBZ-2522: Add support for OAuth password grant using MIC

### DIFF
--- a/src/core/request/network.js
+++ b/src/core/request/network.js
@@ -497,7 +497,7 @@ export class KinveyRequest extends NetworkRequest {
               .find(sessionKey => socialIdentity[sessionKey].identity === 'kinveyAuth');
             const oldSession = socialIdentity[sessionKey];
 
-            if (isDefined(oldSession)) {
+            if (isDefined(oldSession) && oldSession.refresh_token && oldSession.redirect_uri) {
               const request = new KinveyRequest({
                 method: RequestMethod.POST,
                 headers: {

--- a/src/core/user/user.js
+++ b/src/core/user/user.js
@@ -293,6 +293,44 @@ export class User {
   }
 
   /**
+   * Login using Mobile Identity Connect.
+   *
+   * @param {string} username Username.
+   * @param {string} password Password.
+   * @param {Object} [options] Options
+   * @return {Promise<User>} The user.
+   */
+  loginWithMICUsingUsernamePassword(username, password, options = {}) {
+    const isActive = this.isActive();
+    const activeUser = User.getActiveUser(this.client);
+
+    if (isActive) {
+      return Promise.reject(new ActiveUserError('This user is already the active user.'));
+    }
+
+    if (isDefined(activeUser)) {
+      return Promise.reject(new ActiveUserError('An active user already exists. Please logout the active user before you login.'));
+    }
+
+    const mic = new MobileIdentityConnect({ client: this.client });
+    return mic.loginWithUsernamePassword(username, password, options)
+      .then(session => this.connectIdentity(MobileIdentityConnect.identity, session, options));
+  }
+
+  /**
+   * Login using Mobile Identity Connect.
+   *
+   * @param {string} username Username.
+   * @param {string} password Password.
+   * @param {Object} [options] Options
+   * @return {Promise<User>} The user.
+   */
+  static loginWithMICUsingUsernamePassword(username, password, options = {}) {
+    const user = new this({}, options);
+    return user.loginWithMIC(username, password, options);
+  }
+
+  /**
    * Connect a social identity.
    *
    * @param {string} identity Social identity.


### PR DESCRIPTION
#### Description
Add supports for the oauth resource owner credentials grant as part of the KAS OAuth2 implementation.
https://tools.ietf.org/html/rfc6749#section-4.3

#### Changes
- Add `loginWithMICUsingUsernamePassword()` function to `User` class.
- Update refresh token logic to ignore refreshing if a `refresh_token` and `redirect_uri` are not present on the stored session.