### PR TITLE
MLIBZ-2732: Fix multiple messages being received when PubNub is reconnected

### DIFF
--- a/src/core/live/live-service.js
+++ b/src/core/live/live-service.js
@@ -77,7 +77,7 @@ export class LiveService {
     return this.registerUser(user)
       .then((pubnubConfig) => {
         // const copy = extend({}, pubnubConfig);
-        const pubnubClient = new PubNub(pubnubConfig);
+        const pubnubClient = new PubNub(Object.assign({ dedupeOnSubscribe: true }, pubnubConfig));
         const listener = new PubNubListener();
         this.initialize(pubnubClient, listener);
         // return copy;


### PR DESCRIPTION
#### Description
NativeScript apps are often put in the background or experiencing a loss of network connectivity for a short time period. These states will cause the PubNub client to disconnect. To fix this issue we attempt to reconnect the PubNub client when the app is resumed or network connectivity, However, this also caused a problem where messages would begin doubling or even tripling. To fix this issue we have added the `dedupeOnSubscribe` flag to the PubNub client config.

#### Changes
- Added `dedupeOnSubscribe` flag to PubNub client config.