### PR TITLE
Print the correct warn message for resume scheme

### DIFF
--- a/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
+++ b/packages/kinvey-nativescript-sdk/lib/before-preview-sync.js
@@ -1,8 +1,6 @@
 module.exports = function ($logger, hookArgs) {
-  const platform = hookArgs && hookArgs.config && hookArgs.config.platform && hookArgs.config.platform.toLowerCase();
-  const projectIdentifier = platform && hookArgs.projectData && hookArgs.projectData.projectIdentifiers && hookArgs.projectData.projectIdentifiers[platform];
+  const previewAppSchema = hookArgs && hookArgs.projectData && hookArgs.projectData.previewAppSchema;
+  const previewResumeScheme = previewAppSchema === "kspreview" ? "kspreviewresume://" : "nsplayresume://";
 
-  const previewScheme = projectIdentifier === "com.kinvey.preview" ? "kspreviewresume://" : "nsplayresume://";
-
-  $logger.warn(`If you are using loginWithMIC() ensure that you have added ${previewScheme} as a Redirect URI to your Mobile Identity Connect configuration at https://console.kinvey.com in order for Mobile Identity Connect login to work in the Preview app.`);
+  $logger.warn(`If you are using loginWithMIC() ensure that you have added ${previewResumeScheme} as a Redirect URI to your Mobile Identity Connect configuration at https://console.kinvey.com in order for Mobile Identity Connect login to work in the Preview app.`);
 };


### PR DESCRIPTION
#### Description

The projectIdentifier is the identifier of the NS application that the user is working on, not the identifier of the preview app. However, we can check which preview app the NS application is working with by checking the previewAppSchema of the NS application.

#### Changes
Fix the warn message to pint the correct resume scheme.
