### PR TITLE
fix: androidx compatibility

### DIFF
--- a/packages/nativescript-sdk/src/nativescript/popup/popup.android.ts
+++ b/packages/nativescript-sdk/src/nativescript/popup/popup.android.ts
@@ -11,9 +11,10 @@ import { handleOpenURL, AppURL } from 'nativescript-urlhandler';
 const LOADED_EVENT = 'loaded';
 const CLOSED_EVENT = 'closed';
 const ERROR_EVENT = 'error';
+declare const global;
 
-const androidSupport: any = android.support;
-const customtabs = androidSupport.customtabs || {};
+const customtabsPackage: any = global.androidx && global.androidx.browser ? global.androidx.browser : android.support;
+const customtabs = customtabsPackage.customtabs || {};
 const CustomTabsCallback = customtabs.CustomTabsCallback;
 const CustomTabsServiceConnection = customtabs.CustomTabsServiceConnection;
 const CustomTabsIntent = customtabs.CustomTabsIntent;


### PR DESCRIPTION
#### Description
As the `kinvey-nativescript-sdk` package uses the old Android Support Libraries, it will not be compatible with the upcoming NativeScript 6.0 release which will use [AndroidX by default](https://www.nativescript.org/blog/support-for-androidx-in-nativescript). The changes from this PR, make the package compatible with the AndroidX library (NS 6.0) and with the old libraries (NS before 6.0).

#### Changes
Use CustomTabs on android from the AndroidX Library if it is available (when project uses tns-android@6.0) or use it from the old support library otherwise (when project uses tns-android version before 6.0).