### PR TITLE
feat: make hooks compatible for Nativescript 6.0 release

### DIFF
--- a/packages/nativescript-sdk/nativescript-hook-scripts/before-checkForChanges.js
+++ b/packages/nativescript-sdk/nativescript-hook-scripts/before-checkForChanges.js
@@ -5,12 +5,11 @@ const pkg = require('../package.json');
 
 module.exports = function (hookArgs) {
   return new Promise((resolve, reject) => {
-    const appDirectoryPath = hookArgs && hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectData && hookArgs.checkForChangesOpts.projectData.appDirectoryPath;
-
+    const appDirectoryPath = ((hookArgs && hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectData && hookArgs.checkForChangesOpts.projectData) || hookArgs.projectData).appDirectoryPath;
     if (!appDirectoryPath) {
       reject(new Error('Unable to get path to app directory'));
     } else {
-      const platform = (hookArgs && hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.platform.toLowerCase()) || '';
+      const platform = (((hookArgs && hookArgs.checkForChangesOpts) || hookArgs.prepareData).platform || '').toLowerCase();
       const pathToPackageJson = path.join(appDirectoryPath, 'package.json');
       const packageJsonContent = JSON.parse(fs.readFileSync(pathToPackageJson));
       const kinveyData = packageJsonContent.pluginsData && packageJsonContent.pluginsData[pkg.name];

--- a/packages/nativescript-sdk/nativescript-hook-scripts/before-preview-sync.js
+++ b/packages/nativescript-sdk/nativescript-hook-scripts/before-preview-sync.js
@@ -1,5 +1,5 @@
 module.exports = function ($logger, hookArgs) {
-  const platform = hookArgs && hookArgs.config && hookArgs.config.platform && hookArgs.config.platform.toLowerCase();
+  const platform = hookArgs && ((hookArgs.config && hookArgs.config.platform) || (hookArgs.platform || '')).toLowerCase();
   const projectIdentifier = platform && hookArgs.projectData && hookArgs.projectData.projectIdentifiers && hookArgs.projectData.projectIdentifiers[platform];
   const previewScheme = projectIdentifier === 'com.kinvey.preview' ? 'kspreviewresume://' : 'nsplayresume://';
   $logger.warn(`If you are using loginWithMIC() ensure that you have added ${previewScheme} as a Redirect URI to your Mobile Identity Connect configuration at https://console.kinvey.com in order for Mobile Identity Connect login to work in the Preview app.`);


### PR DESCRIPTION
In NativeScript 6.0.0 there's a major refactoring in CLI that will require changes in most of the plugin hooks.
The major changes are the hookArgs injected by CLI for each hook - they are changed, so some of the properties used from them, should be taken from different property.
The other major change is the injected data - in the function used as hook, you can use any service registered in CLI's bootstrap and CLI will pass it to the hook.
Several of the services are now renamed or deleted, so hooks using them should be migrated. Such service is platformsData.
The last major change is that some logger methods are deleted (they've been deprecated).

The current PR makes the hooks of this plugin compatible with the both 6.0.0 and old releases of NativeScript.