### PR TITLE
MLIBZ-2700: Verify arguments for ascending() and descending() on Query class

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "prebuild": "del lib",
     "build": "tsc -p tsconfig.json",
-    "test": "mocha --require ts-node/register test/**/*.spec.ts",
-    "test:watch": "mocha --require ts-node/register test/**/*.spec.ts --watch --watch-extensions ts"
+    "test": "mocha --require ts-node/register \"test/**/*.spec.ts\"",
+    "test:watch": "mocha --require ts-node/register \"test/**/*.spec.ts\" --watch --watch-extensions ts"
   },
   "dependencies": {
     "events": "3.0.0",

--- a/packages/js-sdk/src/query.ts
+++ b/packages/js-sdk/src/query.ts
@@ -521,6 +521,10 @@ export class Query {
    * @returns {Query} Query
    */
   ascending(field: string) {
+    if (!isString(field)) {
+      throw new QueryError('The provided field must be a string.');
+    }
+
     if (this._parent) {
       this._parent.ascending(field);
     } else {
@@ -542,6 +546,10 @@ export class Query {
    * @returns {Query} Query
    */
   descending(field: string) {
+    if (!isString(field)) {
+      throw new QueryError('The provided field must be a string.');
+    }
+
     if (this._parent) {
       this._parent.descending(field);
     } else {

--- a/packages/js-sdk/test/query.spec.ts
+++ b/packages/js-sdk/test/query.spec.ts
@@ -1,0 +1,47 @@
+/// <reference types="mocha" />
+
+import { expect } from 'chai';
+import { Query } from '../src/query';
+import { QueryError } from '../src/errors/query';
+
+describe('Query', function () {
+  describe('ascending()', function() {
+    it('should throw an error if the field is not a string', function() {
+      try {
+        const query = new Query();
+        // @ts-ignore
+        query.ascending();
+      } catch (error) {
+        expect(error).to.be.instanceOf(QueryError);
+        expect(error.message).to.equal('The provided field must be a string.')
+      }
+    });
+
+    it('should sort the field ascending', function () {
+      const field = 'field';
+      const query = new Query();
+      query.ascending(field);
+      expect(query.sort[field]).to.equal(1);
+    });
+  });
+
+  describe('descending()', function () {
+    it('should throw an error if the field is not a string', function () {
+      try {
+        const query = new Query();
+        // @ts-ignore
+        query.descending();
+      } catch (error) {
+        expect(error).to.be.instanceOf(QueryError);
+        expect(error.message).to.equal('The provided field must be a string.')
+      }
+    });
+
+    it('should sort the field descending', function () {
+      const field = 'field';
+      const query = new Query();
+      query.descending(field);
+      expect(query.sort[field]).to.equal(-1);
+    });
+  });
+});


### PR DESCRIPTION
#### Description
The `Query` class will set `{ sort: { "undefined"; 1 }` if you don't provide a value to `ascending()`. The same is true for `descending()` too.

#### Changes
- Verify arguments to `ascending()` and `descending()`.
- Add unit tests
- Update test scripts to run all unit tests
