### PR TITLE
MLIBZ-2701: Verify arguments to Query.exists()

### DIFF
--- a/packages/js-sdk/src/query.ts
+++ b/packages/js-sdk/src/query.ts
@@ -699,6 +699,10 @@ export class Query {
    * @returns {Query} Query
    */
   addFilter(field: string, ...args: any) {
+    if (!isString(field)) {
+      throw new QueryError('The field argument must be a string.');
+    }
+
     const { condition, values } = args.length === 2
       ? { condition: args[0], values: args[1] }
       : { condition: undefined, values: args[0] };

--- a/packages/js-sdk/test/query.spec.ts
+++ b/packages/js-sdk/test/query.spec.ts
@@ -5,6 +5,40 @@ import { Query } from '../src/query';
 import { QueryError } from '../src/errors/query';
 
 describe('Query', function () {
+  describe('exists()', function() {
+    it('should throw an error if the field is not a string', function () {
+      try {
+        const query = new Query();
+        // @ts-ignore
+        query.exists();
+      } catch (error) {
+        expect(error).to.be.instanceOf(QueryError);
+        expect(error.message).to.equal('The field argument must be a string.')
+      }
+    });
+
+    it('should add the $exists filter to true by default', function () {
+      const field = 'field';
+      const query = new Query();
+      query.exists(field);
+      expect(query.filter[field]).to.deep.equal({ $exists: true });
+    });
+
+    it('should add the $exists filter to true', function () {
+      const field = 'field';
+      const query = new Query();
+      query.exists(field, true);
+      expect(query.filter[field]).to.deep.equal({ $exists: true });
+    });
+
+    it('should add the $exists filter to false', function () {
+      const field = 'field';
+      const query = new Query();
+      query.exists(field, false);
+      expect(query.filter[field]).to.deep.equal({ $exists: false });
+    });
+  });
+
   describe('ascending()', function() {
     it('should throw an error if the field is not a string', function() {
       try {


### PR DESCRIPTION
#### Description
If a field is not provided to exists then `{ "undefined": { $exists: true }}` is added as a filter.

#### Changes
- Verify arguments to `addFilter()`
- Add unit tests
