### PR TITLE
chore: remove angular as peer dependency from nativescript sdk

### DIFF
--- a/packages/nativescript-sdk/package.json
+++ b/packages/nativescript-sdk/package.json
@@ -40,7 +40,6 @@
     "pubnub": "https://github.com/thomasconner/javascript/tarball/67b7944366453a87226389d483ac1ad861e0e129"
   },
   "peerDependencies": {
-    "@angular/core": "~7.2.0",
     "nativescript-plugin-firebase": "~8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Description
When kinvey-nativescript-sdk is used in a non angular nativescript app, there is a warning in the terminal that peer dependency of @angular/core is missing. This confuses users and the dependency is not really needed in their case.

In nativescript plugins we add angular only as dev dependency, and it is required only when you use <your-plugin>/angular. I doubt that anyone would use the angular implementation in a non angular app.

#### Changes
Remove @angular/core from dev dependencies of kinvey-nativescript-sdk
