### PR TITLE
Add support for push notifications to React Native SDK

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,4 +18,5 @@ task:
     fingerprint_script: cat package-lock.json
     populate_script: npm ci
   bootstrap_script: ./node_modules/.bin/lerna bootstrap
+  build_script: ./node_modules/.bin/lerna run --scope kinvey-js-sdk --scope kinvey-react-native-sdk --stream build
   test_script: ./node_modules/.bin/lerna run --scope kinvey-react-native-sdk --stream test

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -503,9 +503,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "24.0.17",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.17.tgz",
-			"integrity": "sha512-1cy3xkOAfSYn78dsBWy4M3h/QF/HeWPchNFDjysVtp3GHeTdSmtluNnELfCmfNRRHo0OWEcpf+NsEJQvwQfdqQ==",
+			"version": "24.0.18",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
+			"integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
 			"dev": true,
 			"requires": {
 				"@types/jest-diff": "*"
@@ -651,9 +651,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -1360,6 +1360,19 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
 		"cssom": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -1689,9 +1702,9 @@
 			}
 		},
 		"eslint": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.1.tgz",
+			"integrity": "sha512-ES7BzEzr0Q6m5TK9i+/iTpKjclXitOdDK4vT07OqbkBT2/VcN/gO9EL1C4HlK3TAOXYv2ItcmbVR9jO1MR0fJg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -1701,9 +1714,9 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^6.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.0",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
@@ -1739,27 +1752,6 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-							"dev": true
-						}
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1778,6 +1770,21 @@
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
+				},
+				"eslint-utils": {
+					"version": "1.4.2",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+					"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -1799,12 +1806,6 @@
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
-				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-					"dev": true
 				}
 			}
 		},
@@ -1820,20 +1821,12 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
-			"integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.1.0.tgz",
+			"integrity": "sha512-k9fny9sPjIBQ2ftFTesJV21Rg4R/7a7t7LCtZVrYQiHEp8Nnuk3EGaDmsKSAnsPj0BYcgB2zxzHa2NTkIxcOLg==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
-			},
-			"dependencies": {
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -2016,14 +2009,28 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-			"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.0.0",
+				"acorn-jsx": "^5.0.2",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+					"dev": true
+				},
+				"eslint-visitor-keys": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -2970,6 +2977,12 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+			"dev": true
+		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -3287,9 +3300,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -6188,6 +6201,12 @@
 			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
 			"dev": true
 		},
+		"strip-json-comments": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+			"dev": true
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6204,9 +6223,9 @@
 			"dev": true
 		},
 		"table": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
-			"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",

--- a/packages/react-native-sdk/.eslintrc
+++ b/packages/react-native-sdk/.eslintrc
@@ -12,6 +12,7 @@
         "no-undef": "off",
         "no-unused-expressions": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
+        "import/first": "off",
         "import/no-extraneous-dependencies": "off",
         "jest/no-disabled-tests": "warn",
         "jest/no-focused-tests": "error",

--- a/packages/react-native-sdk/.eslintrc
+++ b/packages/react-native-sdk/.eslintrc
@@ -5,12 +5,20 @@
   },
   "overrides": [
     {
-      "files": ["jest/**/*.js", "jest/**/*.ts", "**/*.spec.js", "**/*.spec.ts"],
+      "files": [
+        "jest/**/*.js",
+        "jest/**/*.ts",
+        "**/*.spec.js",
+        "**/*.spec.ts",
+        "__mocks__/**/*.js",
+        "__mocks__/**/*.ts"
+      ],
       "rules": {
         "spaced-comment": "off",
         "func-names": "off",
         "no-undef": "off",
         "no-unused-expressions": "off",
+        "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "import/first": "off",
         "import/no-extraneous-dependencies": "off",

--- a/packages/react-native-sdk/.gitignore
+++ b/packages/react-native-sdk/.gitignore
@@ -36,3 +36,6 @@ lib
 # Code Coverage
 .nyc_output
 coverage
+
+# Jest
+__mocks__

--- a/packages/react-native-sdk/package-lock.json
+++ b/packages/react-native-sdk/package-lock.json
@@ -1210,6 +1210,15 @@
 				"node-fetch": "^2.5.0"
 			}
 		},
+		"@react-native-community/push-notification-ios": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@react-native-community/push-notification-ios/-/push-notification-ios-1.0.2.tgz",
+			"integrity": "sha512-9lWaw+zBGvT8Yw9HZmiLkYbnmF5AzrWexYh2qmRt/shpfZawCTPmPBrq09N7JhiPV4g/gEbeLXlndxl1JQeB0g==",
+			"dev": true,
+			"requires": {
+				"invariant": "^2.2.4"
+			}
+		},
 		"@types/babel__core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -1300,9 +1309,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "24.0.17",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.17.tgz",
-			"integrity": "sha512-1cy3xkOAfSYn78dsBWy4M3h/QF/HeWPchNFDjysVtp3GHeTdSmtluNnELfCmfNRRHo0OWEcpf+NsEJQvwQfdqQ==",
+			"version": "24.0.18",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
+			"integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
 			"dev": true,
 			"requires": {
 				"@types/jest-diff": "*"
@@ -1318,6 +1327,12 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.138",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
+			"integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -1357,6 +1372,12 @@
 				"@types/prop-types": "*",
 				"@types/react": "*"
 			}
+		},
+		"@types/react-native-push-notification": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/react-native-push-notification/-/react-native-push-notification-3.0.6.tgz",
+			"integrity": "sha512-OmgCbcG1d16NKD08Y+ZPrbdiR4z7wig6cj65VSy8Vx4AHq2sTTkKc4V8e65nNDeFj4oscGFiJCljyRYZ5xb7bA==",
+			"dev": true
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -1481,9 +1502,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -1523,13 +1544,10 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-			"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.5.2"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-fragments": {
 			"version": "0.2.1",
@@ -1716,6 +1734,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
 		"assign-symbols": {
@@ -2215,6 +2239,20 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
+		"chai": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2230,6 +2268,12 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
 		"ci-info": {
@@ -2262,12 +2306,12 @@
 			}
 		},
 		"cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^3.1.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -2699,6 +2743,29 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
+		},
+		"deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+			"dev": true,
+			"requires": {
+				"is-arguments": "^1.0.4",
+				"is-date-object": "^1.0.1",
+				"is-regex": "^1.0.4",
+				"object-is": "^1.0.1",
+				"object-keys": "^1.1.1",
+				"regexp.prototype.flags": "^1.2.0"
+			}
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2872,9 +2939,9 @@
 			"dev": true
 		},
 		"emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
 		"encodeurl": {
@@ -2985,9 +3052,9 @@
 			}
 		},
 		"eslint": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
+			"integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -2997,9 +3064,9 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^6.0.0",
+				"eslint-utils": "^1.4.2",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
@@ -3048,6 +3115,15 @@
 						"estraverse": "^4.1.1"
 					}
 				},
+				"eslint-utils": {
+					"version": "1.4.2",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+					"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -3080,9 +3156,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
-			"integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.1.0.tgz",
+			"integrity": "sha512-k9fny9sPjIBQ2ftFTesJV21Rg4R/7a7t7LCtZVrYQiHEp8Nnuk3EGaDmsKSAnsPj0BYcgB2zxzHa2NTkIxcOLg==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
@@ -3300,14 +3376,22 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-			"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.0.0",
+				"acorn-jsx": "^5.0.2",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -3657,9 +3741,9 @@
 			}
 		},
 		"figures": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4451,6 +4535,12 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
+		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4809,22 +4899,22 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
-			"integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^4.2.1",
+				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
-				"cli-cursor": "^3.1.0",
+				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
-				"figures": "^3.0.0",
-				"lodash": "^4.17.15",
-				"mute-stream": "0.0.8",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.12",
+				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
-				"string-width": "^4.1.0",
+				"string-width": "^2.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
@@ -4877,6 +4967,12 @@
 					}
 				}
 			}
+		},
+		"is-arguments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -4974,9 +5070,9 @@
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
 		},
 		"is-generator-fn": {
@@ -5933,10 +6029,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-			"dev": true
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -7445,9 +7540,9 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
@@ -7499,6 +7594,40 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"nock": {
+			"version": "10.0.6",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+			"integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+			"dev": true,
+			"requires": {
+				"chai": "^4.1.2",
+				"debug": "^4.1.0",
+				"deep-equal": "^1.0.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.5",
+				"mkdirp": "^0.5.0",
+				"propagate": "^1.0.0",
+				"qs": "^6.5.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -7642,6 +7771,12 @@
 				}
 			}
 		},
+		"object-is": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+			"dev": true
+		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7737,12 +7872,20 @@
 			}
 		},
 		"onetime": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^2.1.0"
+				"mimic-fn": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				}
 			}
 		},
 		"open": {
@@ -8020,6 +8163,12 @@
 				}
 			}
 		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8220,6 +8369,12 @@
 				"object-assign": "^4.1.1",
 				"react-is": "^16.8.1"
 			}
+		},
+		"propagate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -8554,6 +8709,15 @@
 				}
 			}
 		},
+		"react-native-push-notification": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/react-native-push-notification/-/react-native-push-notification-3.1.9.tgz",
+			"integrity": "sha512-YpEg9AYBjNgJtHRgHKR0xPB7kk3Gj0uSjUxd0feOIvd7wrfR+zeiBM4NZonGmjlAG6thaE37dfAG5qcsONFM7w==",
+			"dev": true,
+			"requires": {
+				"@react-native-community/push-notification-ios": "^1.0.1"
+			}
+		},
 		"react-native-testing-library": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/react-native-testing-library/-/react-native-testing-library-1.11.1.tgz",
@@ -8688,6 +8852,15 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
+			}
+		},
+		"regexp.prototype.flags": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2"
 			}
 		},
 		"regexpp": {
@@ -8868,12 +9041,12 @@
 			"dev": true
 		},
 		"restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^5.1.0",
+				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
 			}
 		},
@@ -9514,14 +9687,30 @@
 			}
 		},
 		"string-width": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-			"integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^5.2.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string_decoder": {
@@ -9599,18 +9788,6 @@
 				"string-width": "^3.0.0"
 			},
 			"dependencies": {
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
 				"lodash": {
 					"version": "4.17.15",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -9927,10 +10104,10 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-fest": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-			"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
 		"typedarray": {

--- a/packages/react-native-sdk/package-lock.json
+++ b/packages/react-native-sdk/package-lock.json
@@ -1736,12 +1736,6 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-			"dev": true
-		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2239,20 +2233,6 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"dev": true,
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2268,12 +2248,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
-		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
 		},
 		"ci-info": {
@@ -2742,29 +2716,6 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"dev": true,
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
-			"dev": true,
-			"requires": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			}
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -4535,12 +4486,6 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-			"dev": true
-		},
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4967,12 +4912,6 @@
 					}
 				}
 			}
-		},
-		"is-arguments": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -7595,40 +7534,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"nock": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-			"integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
-			"dev": true,
-			"requires": {
-				"chai": "^4.1.2",
-				"debug": "^4.1.0",
-				"deep-equal": "^1.0.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.5",
-				"mkdirp": "^0.5.0",
-				"propagate": "^1.0.0",
-				"qs": "^6.5.1",
-				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -7770,12 +7675,6 @@
 					}
 				}
 			}
-		},
-		"object-is": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -8163,12 +8062,6 @@
 				}
 			}
 		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-			"dev": true
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8369,12 +8262,6 @@
 				"object-assign": "^4.1.1",
 				"react-is": "^16.8.1"
 			}
-		},
-		"propagate": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
-			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -8852,15 +8739,6 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
-			}
-		},
-		"regexp.prototype.flags": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2"
 			}
 		},
 		"regexpp": {
@@ -10103,12 +9981,6 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
-		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -30,16 +30,20 @@
   },
   "dependencies": {
     "axios": "0.19.0",
-    "kinvey-js-sdk": "^4.2.3"
+    "kinvey-js-sdk": "^4.2.3",
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "@react-native-community/async-storage": "^1.6.1",
-    "react-native": "^0.60.5"
+    "react-native": "^0.60.5",
+    "react-native-push-notification": "^3.1.9"
   },
   "devDependencies": {
     "@react-native-community/async-storage": "^1.6.1",
     "@types/jest": "^24.0.18",
+    "@types/lodash": "^4.14.138",
     "@types/react-native": "^0.60.3",
+    "@types/react-native-push-notification": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "del-cli": "2.0.0",
@@ -56,6 +60,7 @@
     "prettier": "^1.18.2",
     "react": "^16.9.0",
     "react-native": "^0.60.5",
+    "react-native-push-notification": "^3.1.9",
     "react-native-testing-library": "~1.11.1",
     "react-test-renderer": "^16.9.0",
     "ts-jest": "^24.0.2",

--- a/packages/react-native-sdk/src/__tests__/push.spec.ts
+++ b/packages/react-native-sdk/src/__tests__/push.spec.ts
@@ -1,0 +1,106 @@
+import isFunction from 'lodash/isFunction';
+import { resolve } from 'path';
+
+const DEVICE_TOKEN = { os: 'MacOs', token: 'token' };
+const PUSH_NOTIFICATION = {
+  foregroup: false,
+  userInteraction: false,
+  message: 'Hello World!',
+  data: { title: 'Test Push Notification' },
+  badge: 0,
+  alert: { title: 'Test Push Notification' },
+  sound: 'alert.wav',
+  finish: jest.fn()
+};
+const PushNotificationMock = {
+  configure: jest.fn((options = {}) => {
+    const { onRegister, onNotification } = options;
+
+    if (isFunction(onRegister)) {
+      onRegister(DEVICE_TOKEN);
+    }
+
+    if (isFunction(onNotification)) {
+      onNotification(PUSH_NOTIFICATION);
+    }
+  }),
+  unregister: jest.fn()
+};
+jest.mock('react-native-push-notification', () => PushNotificationMock);
+
+const KinveyHttpMock = {
+  formatKinveyBaasUrl: jest.fn((namespace, path) => resolve('https://baas.kinvey.com/', namespace, path)),
+  KinveyHttpRequest: jest.fn().mockImplementation(() => {
+    return {
+      execute: jest.fn(() => Promise.resolve())
+    };
+  }),
+  HttpRequestMethod: {
+    POST: 'post'
+  },
+  KinveyHttpAuth: {
+    Session: 'session'
+  },
+  KinveyBaasNamespace: {
+    Push: 'push'
+  }
+};
+jest.mock('kinvey-js-sdk/lib/http', () => KinveyHttpMock);
+
+import { register, unregister } from '../push';
+
+describe('register()', () => {
+  test('should register the device with Kinvey', async () => {
+    await register();
+    expect(KinveyHttpMock.KinveyHttpRequest).toBeCalledWith({
+      method: 'post',
+      auth: 'session',
+      url: '/register-device',
+      body: {
+        platform: 'macos',
+        framework: 'react-native',
+        deviceId: 'token',
+        service: 'firebase'
+      }
+    });
+  });
+
+  test('should return device token', async () => {
+    const token = await register();
+    expect(token).toEqual(DEVICE_TOKEN.token);
+  });
+
+  test('should call onRegister callback', async () => {
+    const onRegister = jest.fn();
+    await register({ onRegister });
+    expect(onRegister).toBeCalledWith(DEVICE_TOKEN);
+  });
+
+  test('should call onNotification callback', async () => {
+    const onNotification = jest.fn();
+    await register({ onNotification });
+    expect(onNotification).toBeCalledWith(PUSH_NOTIFICATION);
+  });
+});
+
+describe('unregister()', () => {
+  test('should unregister the device with Kinvey', async () => {
+    await unregister();
+    expect(KinveyHttpMock.KinveyHttpRequest).toBeCalledWith({
+      method: 'post',
+      auth: 'session',
+      url: '/unregister-device',
+      body: {
+        platform: 'macos',
+        framework: 'react-native',
+        deviceId: 'token',
+        service: 'firebase'
+      }
+    });
+  });
+
+  test('should unregister react native push notification module', async () => {
+    await unregister();
+    expect(PushNotificationMock.unregister).toBeCalled();
+  });
+});

--- a/packages/react-native-sdk/src/push.ts
+++ b/packages/react-native-sdk/src/push.ts
@@ -1,0 +1,81 @@
+import RNPushNotification, { PushNotificationOptions } from 'react-native-push-notification';
+import {
+  formatKinveyBaasUrl,
+  KinveyHttpRequest,
+  HttpRequestMethod,
+  KinveyHttpAuth,
+  KinveyBaasNamespace
+} from 'kinvey-js-sdk/lib/http';
+import isFunction from 'lodash/isFunction';
+
+export { PushNotificationOptions };
+
+async function registerDeviceWithKinvey(os: string, token: string): Promise<void> {
+  const request = new KinveyHttpRequest({
+    method: HttpRequestMethod.POST,
+    auth: KinveyHttpAuth.Session,
+    url: formatKinveyBaasUrl(KinveyBaasNamespace.Push, '/register-device'),
+    body: {
+      platform: os.toLowerCase(),
+      framework: 'react-native',
+      deviceId: token,
+      service: 'firebase'
+    }
+  });
+  await request.execute();
+}
+
+export async function register(options: PushNotificationOptions = {}): Promise<string> {
+  const promise = new Promise<string>((resolve, reject): void => {
+    RNPushNotification.configure({
+      senderID: options.senderID,
+      permissions: options.permissions,
+      popInitialNotification: options.popInitialNotification,
+      onNotification: options.onNotification,
+
+      async onRegister(info) {
+        try {
+          await registerDeviceWithKinvey(info.os, info.token);
+          if (isFunction(options.onRegister)) options.onRegister(info);
+          resolve(info.token);
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+  });
+  return promise;
+}
+
+async function unregisterDeviceWithKinvey(os: string, token: string): Promise<void> {
+  const request = new KinveyHttpRequest({
+    method: HttpRequestMethod.POST,
+    auth: KinveyHttpAuth.Session,
+    url: formatKinveyBaasUrl(KinveyBaasNamespace.Push, '/unregister-device'),
+    body: {
+      platform: os.toLowerCase(),
+      framework: 'react-native',
+      deviceId: token,
+      service: 'firebase'
+    }
+  });
+  await request.execute();
+}
+
+export async function unregister(): Promise<string> {
+  const promise = new Promise<string>((resolve, reject): void => {
+    RNPushNotification.unregister();
+    RNPushNotification.configure({
+      async onRegister(info) {
+        try {
+          unregisterDeviceWithKinvey(info.os, info.token);
+          RNPushNotification.unregister();
+          resolve(info.token);
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+  });
+  return promise;
+}

--- a/packages/react-native-sdk/tsconfig.json
+++ b/packages/react-native-sdk/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "downlevelIteration": true
   },
-  "exclude": ["node_modules", "test", "demo"]
+  "exclude": ["node_modules", "src/**/__tests__", "demo"]
 }


### PR DESCRIPTION
This PR adds support to the `kinvey-react-native-sdk` for push notifications using [react-native-push-notification](https://github.com/zo0r/react-native-push-notification) package.