### PR TITLE
KDEV-861: Do not reject push on multi-insert generic error

### DIFF
--- a/packages/js-sdk/src/datastore/sync.ts
+++ b/packages/js-sdk/src/datastore/sync.ts
@@ -156,7 +156,20 @@ export class Sync {
         })
       );
 
-      const multiInsertResult = await network.create(entitiesForInsert, options);
+      let multiInsertResult;
+      try {
+        multiInsertResult = await network.create(entitiesForInsert, options);
+      } catch (error) {
+        // In case of a general error with the batch insert, simulate per-entity errors
+        return syncDocsForInsert.forEach((doc, index) => {
+          totalPushResults.push({
+            _id: doc.entityId,
+            operation: SyncEvent.Create,
+            entity: entitiesForInsert[index],
+            error
+          });
+        });
+      }
 
       // Process successful inserts
       if (multiInsertResult.entities != null) {
@@ -199,7 +212,7 @@ export class Sync {
             entity: entitiesForInsert[insertError.index],
             error: insertError
           });
-        })
+        });
       }
     };
 


### PR DESCRIPTION
If a generic error occurs with the multi-insert request during `push`, the whole push operation is rejected.
We must catch that error, continue pushing any other changes, and comply to the known result format from the `push` operation. This means adding a result entry for each object that failed to be inserted.
