### PR TITLE
KDEV-865: Catch general errors and aggregate them only for push function

### DIFF
--- a/packages/js-sdk/src/datastore/cachestore.ts
+++ b/packages/js-sdk/src/datastore/cachestore.ts
@@ -347,7 +347,7 @@ export class CacheStore {
   push(query?: Query, options: any = {}) {
     const sync = new Sync(this.collectionName, this.tag);
     // eslint-disable-next-line no-param-reassign
-    options.catchGenericErrors = true;
+    options.catchGeneralErrors = true;
     return sync.push(undefined, options);
   }
 

--- a/packages/js-sdk/src/datastore/cachestore.ts
+++ b/packages/js-sdk/src/datastore/cachestore.ts
@@ -344,8 +344,10 @@ export class CacheStore {
     return { count };
   }
 
-  push(query?: Query, options?: any) {
+  push(query?: Query, options: any = {}) {
     const sync = new Sync(this.collectionName, this.tag);
+    // eslint-disable-next-line no-param-reassign
+    options.catchGenericErrors = true;
     return sync.push(undefined, options);
   }
 

--- a/packages/js-sdk/src/datastore/sync.ts
+++ b/packages/js-sdk/src/datastore/sync.ts
@@ -156,7 +156,7 @@ export class Sync {
         multiInsertResult = await network.create(entitiesForInsert, options);
       } catch (error) {
         // In case of a general batch insert error, do not break the push operation and aggregate all errors in the result
-        if (options.catchGenericErrors === true) {
+        if (options.catchGeneralErrors === true) {
           return syncDocsForInsert.forEach((doc, index) => {
             totalPushResults.push({
               _id: doc.entityId,

--- a/packages/js-sdk/src/datastore/sync.ts
+++ b/packages/js-sdk/src/datastore/sync.ts
@@ -155,15 +155,19 @@ export class Sync {
       try {
         multiInsertResult = await network.create(entitiesForInsert, options);
       } catch (error) {
-        // In case of a general error with the batch insert, simulate per-entity errors
-        return syncDocsForInsert.forEach((doc, index) => {
-          totalPushResults.push({
-            _id: doc.entityId,
-            operation: SyncEvent.Create,
-            entity: entitiesForInsert[index],
-            error
+        // In case of a general batch insert error, do not break the push operation and aggregate all errors in the result
+        if (options.catchGenericErrors === true) {
+          return syncDocsForInsert.forEach((doc, index) => {
+            totalPushResults.push({
+              _id: doc.entityId,
+              operation: SyncEvent.Create,
+              entity: entitiesForInsert[index],
+              error
+            });
           });
-        });
+        }
+
+        throw error;
       }
 
       // Process successful inserts


### PR DESCRIPTION
The previous fix #567 should be applied only for `push` function, because it may perform different CRUD actions and should not stop on first error. For other operations like create or update, the general error should be thrown immediately.