### PR TITLE
KDEV-1451: {N} SDK - Fix webpack failing to find firebase messaging package

### DIFF
--- a/packages/nativescript-sdk/package-lock.json
+++ b/packages/nativescript-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-nativescript-sdk",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/nativescript-sdk/package.json
+++ b/packages/nativescript-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-nativescript-sdk",
   "description": "Kinvey JavaScript SDK for NativeScript applications.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/nativescript-sdk",
   "repository": {

--- a/packages/nativescript-sdk/src/nativescript/push.ts
+++ b/packages/nativescript-sdk/src/nativescript/push.ts
@@ -1,4 +1,5 @@
-import { firebase, messaging } from '@nativescript/firebase';
+import { firebase } from '@nativescript/firebase';
+import { messaging } from '@nativescript/firebase/messaging';
 import { Device } from '@nativescript/core';
 import { formatKinveyBaasUrl, KinveyHttpRequest, HttpRequestMethod, KinveyHttpAuth, KinveyBaasNamespace } from 'kinvey-js-sdk/lib/http';
 


### PR DESCRIPTION
Importing
```ts
import { firebase, messaging } from '@nativescript/firebase';
```
Is being compiled by webpack expecting `@nativescript/firebase/firebase.js` to have a `messaging` export, but there is no such export and the import fails.
