### PR TITLE
KDEV-721: Use all Query instance features when doing an autoStore.find()

### DIFF
--- a/packages/js-sdk/src/datastore/autostore.ts
+++ b/packages/js-sdk/src/datastore/autostore.ts
@@ -12,15 +12,19 @@ export class AutoStore extends CacheStore {
   }
 
   async find(query?: Query, options: any = {}) {
-    const cache = new DataStoreCache(this.collectionName, this.tag);
-
     if (query && !(query instanceof Query)) {
       throw new KinveyError('query is not an instance of the Query class.')
     }
 
+    const cache = new DataStoreCache(this.collectionName, this.tag);
+    const useDeltaSet = options.useDeltaSet === true || this.useDeltaSet;
+
     try {
-      await this.pull(query, options);
-      return cache.find(query);
+      if (useDeltaSet) {
+        await this.pull(query, options);
+        return await cache.find(query);
+      }
+      return await this._pullInternal(query, options);
     } catch (error) {
       if (error instanceof NetworkError) {
         return cache.find(query);
@@ -32,7 +36,7 @@ export class AutoStore extends CacheStore {
 
   async count(query?: Query, options: any = {}) {
     if (query && !(query instanceof Query)) {
-      throw new KinveyError('query is not an instance of the Query class.')
+      throw new KinveyError('query is not an instance of the Query class.');
     }
 
     try {
@@ -50,7 +54,7 @@ export class AutoStore extends CacheStore {
   }
 
   async group(aggregation: Aggregation, options: any = {}) {
-    if (!(aggregation instanceof Query)) {
+    if (!(aggregation instanceof Aggregation)) {
       throw new KinveyError('aggregation is not an instance of the Aggregation class.')
     }
 

--- a/packages/js-sdk/src/query.ts
+++ b/packages/js-sdk/src/query.ts
@@ -5,6 +5,7 @@ import isObject from 'lodash/isObject';
 import isEmpty from 'lodash/isEmpty';
 import isArray from 'lodash/isArray';
 import cloneDeep from 'lodash/cloneDeep';
+import pick from 'lodash/pick';
 import sift from 'sift';
 import { QueryError } from './errors/query';
 
@@ -839,15 +840,7 @@ export class Query {
       }
 
       if (isArray(queryPlainObject.fields) && queryPlainObject.fields.length > 0) {
-        processedDocs = processedDocs.map((doc) => {
-          const modifiedDoc: any = doc;
-          Object.keys(modifiedDoc).forEach((key) => {
-            if (queryPlainObject.fields && queryPlainObject.fields.indexOf(key) === -1 && PROTECTED_FIELDS.indexOf(key) === -1) {
-              delete modifiedDoc[key];
-            }
-          });
-          return modifiedDoc;
-        });
+        processedDocs = processedDocs.map(d => pick(d, ...PROTECTED_FIELDS, ...queryPlainObject.fields));
       }
 
       return processedDocs;

--- a/tests/integration/specs/common/autostore.spec.js
+++ b/tests/integration/specs/common/autostore.spec.js
@@ -108,11 +108,14 @@ describe('AutoStore', function() {
         expect(docs.length).to.equal(1);
         expect(docs).to.deep.equal([sampleDocs[1]]);
 
-        // Verify that the docs are stored in the cache that match the query
         const syncTypeCollection = DataStore.collection(collectionName, DataStoreType.Sync);
-        const cachedDocs = await syncTypeCollection.find(query).toPromise();
-        expect(cachedDocs.length).to.equal(1);
-        expect(cachedDocs).to.deep.equal([sampleDocs[1]]);
+        const docsMatchingQuery = await syncTypeCollection.find(query).toPromise();
+        expect(docsMatchingQuery.length).to.equal(0); // we only have 1 item locally and it represents page 2 on the server
+
+        // Verify that the docs are stored in the cache that match the query
+        const allOfflineDocs = await syncTypeCollection.find().toPromise();
+        expect(allOfflineDocs.length).to.equal(1);
+        expect(allOfflineDocs).to.deep.equal([sampleDocs[1]]);
       });
 
       it('should return correct data with delta set', async function () {

--- a/tests/integration/specs/utils.js
+++ b/tests/integration/specs/utils.js
@@ -184,9 +184,19 @@ export function validateEntity(dataStoreType, collectionName, expectedEntity, se
     });
 }
 
+export function createDocsOnServer(collectionName, docs) {
+  const collection = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Network);
+  return collection.create(docs)
+    .then(({ errors, entities }) => {
+      if (errors.length) {
+        return Promise.reject(errors);
+      }
+      return entities;
+    });
+}
+
 export function createSampleCollectionData(collectionName, count = 1, propertyName = '') {
   const docs = [];
-  const collection = Kinvey.DataStore.collection(collectionName, Kinvey.DataStoreType.Network);
 
   for (let i = 0; i < count; i++) {
     const doc = {};
@@ -196,8 +206,8 @@ export function createSampleCollectionData(collectionName, count = 1, propertyNa
     docs.push(doc);
   }
 
-  const promises = docs.map((doc) => collection.save(doc));
-  return Promise.all(promises);
+  return createDocsOnServer(collectionName, docs)
+    .catch(errors => Promise.reject(errors[0]));
 }
 
 export async function cleanUpCollectionData(collectionName) {


### PR DESCRIPTION
#### Description
AutoStore now uses the specified paging settings (skip, limit) and projection, when performing a `.find()`. This will bring about a side effect that fetching pages in a non-sequential manner could result in discrepancies between what's been fetched and what is stored for offline use. We will be addressing this issue in a planned later redesign of the AutoStore.

#### Changes
- Extract the logic to be used for `.find()` in a separate method and preserve the current behaviour of `.pull()` and `CacheStore.find()`
- Use the old `AutoStore.find()` logic when using delta set, for the time being
- Fix a wrong validation for `AutoStore.group()` which prevented its use
- `AutoStore.find()` with a projection (the `fields` query option) fetches all fields from the server, stores them offline and then prunes unwated fields before returning the result. The reason is that the items can be used with different projections offline and to support updates without removing fields on the server.