### PR TITLE
fix(cachestore): typeerror: reduce of empty array with no initial value

### DIFF
--- a/packages/js-sdk/src/datastore/cachestore.ts
+++ b/packages/js-sdk/src/datastore/cachestore.ts
@@ -483,9 +483,9 @@ export class CacheStore {
       await queryCache.save(queryCacheDoc);
 
       if (returnCounts) {
-        return paginationResults.reduce((result: number, current: number) => (result + current));
+        return paginationResults.reduce((result: number, current: number) => (result + current), []);
       }
-      return paginationResults.reduce((result: any[], pageDocs: any[]) => result.concat(pageDocs));
+      return paginationResults.reduce((result: any[], pageDocs: any[]) => result.concat(pageDocs), []);
     }
 
     // Find the docs on the backend


### PR DESCRIPTION
paginationResults.reduce() called without an initial value fails when paginationResults is empty.

#### Description
autostore pull fails when no pagination is needed

#### Changes
add initial empty array
