### PR TITLE
KDEV-1645: Fix pull() for offline stores

### DIFF
--- a/packages/js-sdk/src/datastore/cachestore.ts
+++ b/packages/js-sdk/src/datastore/cachestore.ts
@@ -483,9 +483,9 @@ export class CacheStore {
       await queryCache.save(queryCacheDoc);
 
       if (returnCounts) {
-        return paginationResults.reduce((result: number, current: number) => (result + current));
+        return paginationResults.reduce((result: number, current: number) => (result + current), 0);
       }
-      return paginationResults.reduce((result: any[], pageDocs: any[]) => result.concat(pageDocs));
+      return paginationResults.reduce((result: any[], pageDocs: any[]) => result.concat(pageDocs), []);
     }
 
     // Find the docs on the backend

--- a/tests/integration/specs/common/autostore.spec.js
+++ b/tests/integration/specs/common/autostore.spec.js
@@ -555,7 +555,7 @@ describe('AutoStore', function() {
     });
 
     it('should use autopagination when turned on', async function() {
-      const autoTypeCollection = DataStore.collection(collectionName, DataStoreType.Auto, { useAutoPagination: { pageZie: 2 } });
+      const autoTypeCollection = DataStore.collection(collectionName, DataStoreType.Auto, { autoPagination: { pageSize: 2 } });
       const syncTypeCollection = DataStore.collection(collectionName, DataStoreType.Sync);
 
       // Create sample data
@@ -573,6 +573,16 @@ describe('AutoStore', function() {
         const sampleDoc = sampleDocs.find((sampleDoc) => sampleDoc._id === doc._id);
         expect(doc).to.deep.equal(sampleDoc);
       });
+    });
+
+    it('should return 0 when no items exist to be pulled', async function() {
+      const autoTypeCollection = DataStore.collection(collectionName, DataStoreType.Auto, { useAutoPagination: true });
+      const syncTypeCollection = DataStore.collection(collectionName, DataStoreType.Sync);
+
+      expect(await autoTypeCollection.pull(new Query(), { autoPagination: true })).to.equal(0);
+
+      const docs = await syncTypeCollection.find().toPromise();
+      expect(docs.length).to.equal(0);
     });
 
     it('should return error for invalid query');


### PR DESCRIPTION
Ref: https://github.com/Kinvey/js-sdk/pull/589 

Opening a new PR since CI cannot run for code from forks because of secrets. Thanks to @itamitegama for reporting the issue and opening a PR.

#### Description
When doing a pull() with auto pagination enabled, when the server returns no items, an initial value is not provided to .reduce(), causing an unhandled error.

#### Changes
Provide an initial value to `.reduce`. Add a test.
