### PR TITLE
KDEV-1589: Do not use authToken in me method

### DIFF
--- a/packages/js-sdk/src/user/user.ts
+++ b/packages/js-sdk/src/user/user.ts
@@ -111,10 +111,10 @@ export class User {
       method: HttpRequestMethod.GET,
       auth: KinveyHttpAuth.Session,
       url: formatKinveyBaasUrl(KinveyBaasNamespace.User, '/_me'),
-      timeout: options.timeout
+      timeout: options.timeout,
     });
     const response = await request.execute();
-    const data = response.data;
+    const { data } = response;
 
     // Remove sensitive data
     delete data.password;
@@ -126,6 +126,7 @@ export class User {
 
     // Update the active session
     if (this.isActive()) {
+      data._kmd.authtoken = this.authtoken;
       setSession(data);
     }
 

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -336,6 +336,23 @@ describe('User tests', () => {
     });
   });
 
+  describe('me()', () => {
+    let initialActiveUser;
+
+    before(async () => {
+      await safelySignUpUser(utilities.randomString(), null, true, createdUserIds);
+      initialActiveUser = await Kinvey.User.getActiveUser();
+      delete initialActiveUser.data.password;
+    });
+
+    it('should not change authtoken', async () => {
+      const meUser = await Kinvey.User.me();
+      const actualActiveUser = Kinvey.User.getActiveUser();
+      expect(actualActiveUser).to.deep.equal(initialActiveUser);
+      expect(meUser).to.deep.equal(actualActiveUser);
+    });
+  });
+
   describe('update()', () => {
     const username = utilities.randomString();
 


### PR DESCRIPTION
* The v6 `/user/:kid/_me` endpoint does not return a new authentication token, anymore. This PR changes the `User.me()` method to stop counting on receiving a new token from the backend.

