### PR TITLE
KDEV-1770: Fix the angular build

### DIFF
--- a/packages/angular-sdk/src/user.service.ts
+++ b/packages/angular-sdk/src/user.service.ts
@@ -1,8 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
-import { init, User, Query } from 'kinvey-html5-sdk';
+import { init, User, Query, LoginOptions, MFAContext, MFACompleteResult } from 'kinvey-html5-sdk';
 import { KinveyConfigToken } from './utils';
-import { LoginOptions } from "../../js-sdk/src/user/login";
-import { MFACompleteResult, MFAContext } from "../../js-sdk/src/user/loginWithMFA";
 
 @Injectable({
   providedIn: 'root'

--- a/packages/html5-sdk/src/index.ts
+++ b/packages/html5-sdk/src/index.ts
@@ -13,7 +13,10 @@ import {
   Kmd,
   Query,
   User,
-  AuthorizationGrant
+  AuthorizationGrant,
+  LoginOptions,
+  MFAContext,
+  MFACompleteResult,
 } from 'kinvey-js-sdk';
 import { init, initialize } from './init';
 import { StorageProvider } from './storage';
@@ -63,5 +66,8 @@ export {
 
   // User
   User,
-  AuthorizationGrant
+  AuthorizationGrant,
+  LoginOptions,
+  MFAContext,
+  MFACompleteResult,
 };

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -9,7 +9,9 @@ import { Kmd } from './kmd';
 import { logger } from './log';
 import { ping } from './ping';
 import { Query } from './query';
-import { User, AuthorizationGrant} from './user';
+import { User, AuthorizationGrant } from './user';
+import { LoginOptions } from './user/login';
+import { MFAContext, MFACompleteResult } from './user/loginWithMFA';
 import { getAppVersion, setAppVersion } from './http';
 
 const CustomEndpoint = { execute: endpoint };
@@ -58,5 +60,8 @@ export {
 
   // User
   User,
-  AuthorizationGrant
+  AuthorizationGrant,
+  LoginOptions,
+  MFAContext,
+  MFACompleteResult,
 };


### PR DESCRIPTION
* The problem was that there were references to the (core) js sdk in the angular sdk. These references led to the changed folder structure. The interfaces are now exported from the js sdk and then from the html5 sdk to the angular sdk.
