### PR TITLE
Fix {N} MFA tests

### DIFF
--- a/tests/integration/nativescript/scripts/test.js
+++ b/tests/integration/nativescript/scripts/test.js
@@ -110,7 +110,7 @@ fs.copyFileSync(nativescriptSdkFile, path.join(appPath, 'kinvey-nativescript-sdk
 
 // Update the app package.json
 const appPackageJson = require(path.join(appPath, 'package.json'));
-const newDependencies = Object.assign({}, appPackageJson.dependencies, pkg.dependencies, { 'kinvey-js-sdk': 'file:kinvey-js-sdk.tgz', 'kinvey-nativescript-sdk': 'file:kinvey-nativescript-sdk.tgz' });
+const newDependencies = Object.assign({}, appPackageJson.dependencies, pkg.dependencies, { 'kinvey-js-sdk': 'file:kinvey-js-sdk.tgz', 'kinvey-nativescript-sdk': 'file:kinvey-nativescript-sdk.tgz', 'buffer': '6.0.3' });
 const newAppPackageJson = Object.assign({}, appPackageJson, { dependencies: newDependencies });
 fs.outputFileSync(path.join(appPath, 'package.json'), JSON.stringify(newAppPackageJson, null, 4));
 

--- a/tests/integration/specs/common/mfa.spec.js
+++ b/tests/integration/specs/common/mfa.spec.js
@@ -4,6 +4,7 @@ import totp from 'totp.js';
 import * as Kinvey from '__SDK__';
 import * as config from '../config';
 import * as utilities from '../utils';
+global.Buffer = require('buffer/').Buffer;
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));

--- a/tests/integration/specs/common/mfa.spec.js
+++ b/tests/integration/specs/common/mfa.spec.js
@@ -47,7 +47,7 @@ describe('MFA', () => {
       createdUserIds.push(user.data._id);
       userRecoveryCodes = result.userAuthenticator.recoveryCodes;
       userAuthenticators.push(_.pick(result.userAuthenticator, ['id', 'name', 'type']));
-      const oneMoreAuthenticator = await utilities.createVerifiedAuthenticator(user.data._id, appCredentials);
+      const oneMoreAuthenticator = await utilities.createVerifiedAuthenticator();
       userAuthenticators.push(_.pick(oneMoreAuthenticator, ['id', 'name', 'type']));
     });
 
@@ -152,8 +152,8 @@ describe('MFA', () => {
     describe('delete', () => {
       let authenticatorIdToRemove;
       beforeEach('setup authenticators', async () => {
-        ({ id: authenticatorIdToRemove } = await utilities.createVerifiedAuthenticator(user.data._id, appCredentials));
-        await utilities.createVerifiedAuthenticator(user.data._id, appCredentials);
+        ({ id: authenticatorIdToRemove } = await utilities.createVerifiedAuthenticator());
+        await utilities.createVerifiedAuthenticator();
       });
 
       it('Kinvey.MFA.Authenticators.remove() with existing ID should remove authenticator', async () => {
@@ -181,7 +181,7 @@ describe('MFA', () => {
     describe('regenerate recovery codes', () => {
       let oldCodes;
       beforeEach('setup', async () => {
-        await utilities.createVerifiedAuthenticator(user.data._id, appCredentials);
+        await utilities.createVerifiedAuthenticator();
         oldCodes = Kinvey.MFA.listRecoveryCodes();
       });
 

--- a/tests/integration/specs/common/mfa.spec.js
+++ b/tests/integration/specs/common/mfa.spec.js
@@ -4,10 +4,10 @@ import totp from 'totp.js';
 import * as Kinvey from '__SDK__';
 import * as config from '../config';
 import * as utilities from '../utils';
-global.Buffer = require('buffer/').Buffer;
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));
+utilities.tryRequireBuffer();
 
 const namePrefix = 'js-sdk-tests-';
 

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -3,6 +3,7 @@ import totp from 'totp.js';
 import * as Kinvey from '__SDK__';
 import * as config from '../config';
 import * as utilities from '../utils';
+global.Buffer = require('buffer/').Buffer;
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -179,7 +179,7 @@ describe('User tests', () => {
         createdUserIds.push(createdUser.data._id);
       });
 
-      after('cleanup authenticator', async () => utilities.removeAuthenticator(createdUser.data._id, userAuthenticator.id, appCredentials));
+      after('cleanup authenticator', async () => utilities.removeAuthenticator(createdUser, userAuthenticator.id));
 
       describe('login()', () => {
         it('should throw an error', async () => {
@@ -295,7 +295,7 @@ describe('User tests', () => {
             createdUserIds.push(gullibleUser.data._id);
           });
 
-          after('cleanup authenticator', async () => utilities.removeAuthenticator(gullibleUser.data._id, gullibleUserAuthenticator.id, appCredentials));
+          after('cleanup authenticator', async () => utilities.removeAuthenticator(gullibleUser, gullibleUserAuthenticator.id));
 
           it('should not ask the same user for MFA code on second login', async () => {
             const selectAuthenticator = (authenticators) => (authenticators.find((a) => a.id === gullibleUserAuthenticator.id).id);

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -3,10 +3,10 @@ import totp from 'totp.js';
 import * as Kinvey from '__SDK__';
 import * as config from '../config';
 import * as utilities from '../utils';
-global.Buffer = require('buffer/').Buffer;
 
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));
+utilities.tryRequireBuffer();
 
 var appCredentials;
 const collectionName = config.collectionName;

--- a/tests/integration/specs/utils.js
+++ b/tests/integration/specs/utils.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import * as Kinvey from '__SDK__';
 import * as Constants from './constants';
 import totp from 'totp.js';
+global.Buffer = require('buffer/').Buffer;
 
 export function ensureArray(entities) {
   return [].concat(entities);

--- a/tests/integration/specs/utils.js
+++ b/tests/integration/specs/utils.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import * as Kinvey from '__SDK__';
 import * as Constants from './constants';
 import totp from 'totp.js';
-global.Buffer = require('buffer/').Buffer;
 
 export function ensureArray(entities) {
   return [].concat(entities);
@@ -471,5 +470,15 @@ function toBase64(textString) {
     return base64String;
   } else {
     throw new Error("Missing base64 conversion.");
+  }
+}
+
+// The 'buffer' module require hack is needed only for totp.js to work for {N} tests
+export function tryRequireBuffer() {
+  try {
+    global.Buffer = require('buffer/').Buffer;
+  }
+  catch (e) {
+    console.log('tryRequireBuffer(): Buffer could not be loaded.');
   }
 }

--- a/tests/integration/specs/utils.js
+++ b/tests/integration/specs/utils.js
@@ -379,7 +379,7 @@ export async function setupUserWithMFA(appCredentials, shouldLogoutUser = true) 
   const username = randomString();
   const password = randomString();
   const createdUser = await Kinvey.User.signup({ username: username, password: password });
-  const userAuthenticator = await createVerifiedAuthenticator(createdUser.data._id, appCredentials);
+  const userAuthenticator = await createVerifiedAuthenticator();
   if (shouldLogoutUser) {
     await Kinvey.User.logout();
   }
@@ -408,39 +408,19 @@ function buildBaasUrl(path) {
   return `${protocol}://${domain}${path}`;
 }
 
-export async function createVerifiedAuthenticator(userId, sdkConfig, requestLib) {
-  const reqOpts = {
-    headers: {
-      Authorization: `Basic ${getToken(sdkConfig)}`,
-      'Content-Type': 'application/json',
-      'X-Kinvey-API-Version': 6
-    },
-    method: 'POST',
-    url: buildBaasUrl(`/user/${sdkConfig.appKey}/${userId}/authenticators`),
-    data: { type: 'totp', name: 'js-sdk-test' }
-  };
+export function generateMFACode(authenticator) {
+  return new totp(authenticator.config.secret).genOTP();
+}
 
-  const response = await makeRequest(reqOpts, true, requestLib);
-  const authenticator = response.data;
-  reqOpts.url = buildBaasUrl(`/user/${sdkConfig.appKey}/${userId}/authenticators/${authenticator.id}/verify`);
-  reqOpts.data = { code: new totp(authenticator.config.secret).genOTP() };
-  const verifyRes = await makeRequest(reqOpts, true, requestLib);
-  authenticator.recoveryCodes = verifyRes.data.recoveryCodes || [];
+export async function createVerifiedAuthenticator() {
+  const result = await Kinvey.MFA.Authenticators.create({ name: 'js-sdk-tests', type: "totp" }, generateMFACode)
+  const authenticator = result.authenticator;
+  authenticator.recoveryCodes = result.recoveryCodes || [];
   return authenticator;
 }
 
-export async function removeAuthenticator(userId, authenticatorId, sdkConfig, requestLib) {
-  const reqOpts = {
-    headers: {
-      Authorization: `Basic ${getToken(sdkConfig)}`,
-      'Content-Type': 'application/json',
-      'X-Kinvey-API-Version': 6
-    },
-    method: 'DELETE',
-    url: buildBaasUrl(`/user/${sdkConfig.appKey}/${userId}/authenticators/${authenticatorId}`)
-  };
-
-  return makeRequest(reqOpts, true, requestLib);
+export async function removeAuthenticator(user, authenticatorId) {
+  return user.removeAuthenticator(authenticatorId)
 }
 
 async function makeRequest(reqOpts, expectSuccess, requestLib) {


### PR DESCRIPTION
1. Refactored 'createVerifiedAuthenticator' and 'removeAuthenticator' to use the sdk as they hadn't worked in {N}

2. Fixed totp.js "Buffer is not defined" error by adding a hack with a polyfill for 'buffer'.