### PR TITLE
fix(ns): use updated package for urlhandler

### DIFF
--- a/packages/nativescript-sdk/package.json
+++ b/packages/nativescript-sdk/package.json
@@ -36,7 +36,7 @@
     "lodash": "4.17.20",
     "nativescript-hook": "0.2.5",
     "nativescript-sqlite": "~2.6.4",
-    "nativescript-urlhandler": "~1.3.0",
+    "@bradmartin/nativescript-urlhandler": "~2.0.0",
     "pubnub": "https://github.com/kinvey/pubnub-javascript/tarball/67b7944366453a87226389d483ac1ad861e0e129"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Description
<!-- Describe this pull request. Link any issues that it might resolve. -->
Currently the nativescript package will fail due to the urlhandler dep using `"application"` as a module inside the delegate code for iOS. NS7 needs to use the `@nativescript/core` package. I have forked and submitted a PR one year ago to the original plugin with no activity. So the dep listed in this PR works. https://github.com/bradmartin/nativescript-urlhandler.

Linked PR to original dep repo: https://github.com/hypery2k/nativescript-urlhandler/pull/116/files

#### Changes
<!-- List the changes to the SDK made by this pull request. -->
- Change dependency of `nativescript-urlhandler` to `@bradmartin/nativescript-urlhandler` for NS8+ compatibility.
