### PR TITLE
Npm audit update versions

### DIFF
--- a/packages/angular-sdk/CHANGELOG.md
+++ b/packages/angular-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-angular-sdk@7.0.1...kinvey-angular-sdk@7.0.2) (2022-04-28)
+
+* Update package knvey-html5-sdk to fix bug when registering for Live service
+
 ## [7.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-angular-sdk@7.0.0...kinvey-angular-sdk@7.0.1) (2022-04-27)
 
 * Update dependencies to fix known vulnerabilities

--- a/packages/angular-sdk/package-lock.json
+++ b/packages/angular-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-angular-sdk",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2124,21 +2124,21 @@
 			"dev": true
 		},
 		"kinvey-html5-sdk": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/kinvey-html5-sdk/-/kinvey-html5-sdk-7.0.1.tgz",
-			"integrity": "sha512-LNQW7o9LlY2s3JEQeEAes0xXZK92SuwEx4F+tYJLpVb2ZLDvhPmhD2AKYqb68MztfAMyUOUWEb/ma7oJN8RDnQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/kinvey-html5-sdk/-/kinvey-html5-sdk-7.0.2.tgz",
+			"integrity": "sha512-ianPI1A4PCQFRpUCaP+402G3YvPzLKK6qAju373IAyEgxPp4oIQyKFH+f1pyfJ5ncTIkQK5Bl6VPDarJc7zt0A==",
 			"requires": {
 				"axios": "0.26.1",
-				"kinvey-js-sdk": "6.0.1",
+				"kinvey-js-sdk": "6.0.2",
 				"lodash": "4.17.21",
 				"pubnub": "5.0.1",
 				"tslib": "1.10.0"
 			}
 		},
 		"kinvey-js-sdk": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
-			"integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.2.tgz",
+			"integrity": "sha512-hhL/+f3TQvW+vDBaiHIvhrAGFuWhAMf439MTdrdhZqdzHIcsHrvzAcX9TLmsvmdA5PF2iAaAkpEtJm6uKZeU4w==",
 			"requires": {
 				"events": "3.0.0",
 				"js-base64": "2.5.1",

--- a/packages/angular-sdk/package.json
+++ b/packages/angular-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-angular-sdk",
   "description": "Kinvey JavaScript SDK for Angular applications.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/angular-sdk",
   "repository": {
@@ -26,7 +26,7 @@
     "build": "ngc -p tsconfig.json"
   },
   "dependencies": {
-    "kinvey-html5-sdk": "7.0.1",
+    "kinvey-html5-sdk": "7.0.2",
     "tslib": "1.10.0"
   },
   "peerDependencies": {

--- a/packages/html5-sdk/CHANGELOG.md
+++ b/packages/html5-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-html5-sdk@7.0.1...kinvey-html5-sdk@7.0.2) (2022-04-28)
+
+* Update package knvey-js-sdk to fix bug when registering for Live service
+
 ## [7.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-html5-sdk@7.0.0...kinvey-html5-sdk@7.0.1) (2022-04-27)
 
 * Update dependencies to fix known vulnerabilities

--- a/packages/html5-sdk/package-lock.json
+++ b/packages/html5-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-html5-sdk",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3028,9 +3028,9 @@
 			"dev": true
 		},
 		"kinvey-js-sdk": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
-			"integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.2.tgz",
+			"integrity": "sha512-hhL/+f3TQvW+vDBaiHIvhrAGFuWhAMf439MTdrdhZqdzHIcsHrvzAcX9TLmsvmdA5PF2iAaAkpEtJm6uKZeU4w==",
 			"requires": {
 				"events": "3.0.0",
 				"js-base64": "2.5.1",

--- a/packages/html5-sdk/package.json
+++ b/packages/html5-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-html5-sdk",
   "description": "Kinvey JavaScript SDK for HTML5 applications.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/html5-sdk",
   "repository": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "axios": "0.26.1",
-    "kinvey-js-sdk": "6.0.1",
+    "kinvey-js-sdk": "6.0.2",
     "lodash": "4.17.21",
     "pubnub": "5.0.1",
     "tslib": "1.10.0"

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-js-sdk@6.0.1...kinvey-js-sdk@6.0.2) (2022-04-28)
+
+- Version bump for package kinvey-js-sdk
 ## [6.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-js-sdk@6.0.0...kinvey-js-sdk@6.0.1) (2022-04-20)
 
 - Version bump for package kinvey-js-sdk

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-js-sdk",
-	"version": "6.0.0",
+	"version": "6.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-js-sdk",
   "description": "Kinvey JavaScript SDK for JavaScript applications.",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "Apache-2.0",
   "keywords": [
     "Kinvey",

--- a/packages/nativescript-sdk/CHANGELOG.md
+++ b/packages/nativescript-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-nativescript-sdk@7.0.1...kinvey-nativescript-sdk@7.0.2) (2022-04-28)
+
+* Version bump only for package kinvey-js-sdk
+
 # [7.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-nativescript-sdk@7.0.0...kinvey-nativescript-sdk@7.0.1) (2022-04-27)
 
 * Update dependencies to fix known vulnerabilities

--- a/packages/nativescript-sdk/package-lock.json
+++ b/packages/nativescript-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-nativescript-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1140,9 +1140,9 @@
       }
     },
     "kinvey-js-sdk": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
-      "integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.2.tgz",
+      "integrity": "sha512-hhL/+f3TQvW+vDBaiHIvhrAGFuWhAMf439MTdrdhZqdzHIcsHrvzAcX9TLmsvmdA5PF2iAaAkpEtJm6uKZeU4w==",
       "requires": {
         "events": "3.0.0",
         "js-base64": "2.5.1",

--- a/packages/nativescript-sdk/package.json
+++ b/packages/nativescript-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-nativescript-sdk",
   "description": "Kinvey JavaScript SDK for NativeScript applications.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/nativescript-sdk",
   "repository": {
@@ -32,7 +32,7 @@
     "@nativescript/background-http": "~5.0.0",
     "@nativescript/secure-storage": "~3.0.0",
     "events": "3.0.0",
-    "kinvey-js-sdk": "6.0.1",
+    "kinvey-js-sdk": "6.0.2",
     "lodash": "4.17.21",
     "nativescript-hook": "0.2.5",
     "nativescript-sqlite": "~2.6.4",

--- a/packages/node-sdk/CHANGELOG.md
+++ b/packages/node-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-node-sdk@6.0.1...kinvey-node-sdk@6.0.2) (2022-04-28)
+
+* Update package knvey-js-sdk which fixed a bug when registering for Live service
+
 ## [6.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-node-sdk@6.0.0...kinvey-node-sdk@6.0.1) (2022-04-27)
 
 * Update dependencies to fix known vulnerabilities

--- a/packages/node-sdk/package-lock.json
+++ b/packages/node-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-node-sdk",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -728,9 +728,9 @@
 			}
 		},
 		"kinvey-js-sdk": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
-			"integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.2.tgz",
+			"integrity": "sha512-hhL/+f3TQvW+vDBaiHIvhrAGFuWhAMf439MTdrdhZqdzHIcsHrvzAcX9TLmsvmdA5PF2iAaAkpEtJm6uKZeU4w==",
 			"requires": {
 				"events": "3.0.0",
 				"js-base64": "2.5.1",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-node-sdk",
   "description": "Kinvey JavaScript SDK for NodeJS applications.",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/node-sdk",
   "repository": {
@@ -29,7 +29,7 @@
   "dependencies": {
     "axios": "0.26.1",
     "events": "3.0.0",
-    "kinvey-js-sdk": "6.0.1",
+    "kinvey-js-sdk": "6.0.2",
     "lodash": "4.17.21",
     "pubnub": "5.0.1",
     "tslib": "1.10.0"

--- a/packages/react-native-sdk/CHANGELOG.md
+++ b/packages/react-native-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.2](https://github.com/Kinvey/js-sdk/compare/kinvey-react-native-sdk@6.0.1...kinvey-react-native-sdk@6.0.2) (2022-04-28)
+
+* Update package knvey-js-sdk to fix bug when registering for Live service
+
 ## [6.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-react-native-sdk@6.0.0...kinvey-react-native-sdk@6.0.1) (2022-04-27)
 
 * Update dependencies to fix known vulnerabilities

--- a/packages/react-native-sdk/CHANGELOG.md
+++ b/packages/react-native-sdk/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.1](https://github.com/Kinvey/js-sdk/compare/kinvey-react-native-sdk@6.0.0...kinvey-react-native-sdk@6.0.1) (2022-04-27)
+
+* Update dependencies to fix known vulnerabilities
+
 ## [6.0.0](https://github.com/Kinvey/js-sdk/compare/kinvey-react-native-sdk@5.1.1...kinvey-react-native-sdk@6.0.0) (2021-08-24)
 
 - User login with MIC, using the in-app browser [#604](https://github.com/Kinvey/js-sdk/pull/604)

--- a/packages/react-native-sdk/package-lock.json
+++ b/packages/react-native-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-react-native-sdk",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2950,58 +2950,6 @@
 				}
 			}
 		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.32",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.32.tgz",
-			"integrity": "sha512-JzGUVxOFN+RKslJrGAxcq4l6tEmmLY1XuALHINVxc8BJsB4bXOdZzTvxbN9dCPk65Vbulno0B6DmImZ7I6SO8w==",
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.1.1",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"requires": {
-				"tslib": "^2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.7.tgz",
-			"integrity": "sha512-aCNLYdHZkvGH+T8/YBOY33jrVGVuLIa3bpizeHXqwN+P4ZtixhA+kxEEWM1amZwUY2nY/iuj+5jdZn/zB7EPPQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.32",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.6",
-				"tslib": "^2.2.0",
-				"webcrypto-core": "^1.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
 		"@react-native-async-storage/async-storage": {
 			"version": "1.15.4",
 			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
@@ -3624,10 +3572,10 @@
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
 		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
+		"@tsconfig/node12": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.14",
@@ -3885,24 +3833,6 @@
 				}
 			}
 		},
-		"@unimodules/core": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@unimodules/core/-/core-7.1.0.tgz",
-			"integrity": "sha512-oLRT4Bkah3GEopkxmTgpHsRTRp+NJ1907ZjE9y/HLh32q7O/3mcbpY77Uvm+EXW0Vh14gOlU+bmkpC0hz3we0w==",
-			"optional": true,
-			"requires": {
-				"compare-versions": "^3.4.0"
-			}
-		},
-		"@unimodules/react-native-adapter": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-6.2.2.tgz",
-			"integrity": "sha512-hBXL+IX3u+4TcAHu9lIItdycA7pYWZn3Tt7s5TTna9QKHjyrwo0zVss27LkpJ40tXRHyh/GJ8VzN2CD+0M5I2A==",
-			"optional": true,
-			"requires": {
-				"invariant": "^2.2.4"
-			}
-		},
 		"abab": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -3976,21 +3906,6 @@
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"requires": {
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"agentkeepalive": {
@@ -4223,11 +4138,6 @@
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 			"dev": true
 		},
-		"asmcrypto.js": {
-			"version": "0.22.0",
-			"resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
-			"integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -4235,14 +4145,6 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
-			}
-		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"requires": {
-				"pvutils": "^1.0.17"
 			}
 		},
 		"assert-plus": {
@@ -4266,9 +4168,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 				}
 			}
 		},
@@ -4317,27 +4219,11 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
 			"requires": {
-				"follow-redirects": "^1.10.0"
-			}
-		},
-		"b64-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
-			"integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
-			"requires": {
-				"base-64": "^0.1.0"
-			}
-		},
-		"b64u-lite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
-			"integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
-			"requires": {
-				"b64-lite": "^1.4.0"
+				"follow-redirects": "^1.14.8"
 			}
 		},
 		"babel-core": {
@@ -4640,11 +4526,6 @@
 				}
 			}
 		},
-		"base-64": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-			"integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
-		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4759,6 +4640,15 @@
 				"node-int64": "^0.4.0"
 			}
 		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -4792,7 +4682,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -5100,12 +4989,6 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
-		"compare-versions": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
-			"optional": true
-		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -5205,9 +5088,9 @@
 			}
 		},
 		"cookiejar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+			"integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -5351,17 +5234,17 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.1.2"
 			},
 			"dependencies": {
 				"ms": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -5481,13 +5364,14 @@
 			}
 		},
 		"degenerator": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
-			"integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.2.tgz",
+			"integrity": "sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==",
 			"requires": {
 				"ast-types": "^0.13.2",
 				"escodegen": "^1.8.1",
-				"esprima": "^4.0.0"
+				"esprima": "^4.0.0",
+				"vm2": "^3.9.8"
 			}
 		},
 		"del": {
@@ -5529,7 +5413,8 @@
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
 		},
 		"destroy": {
 			"version": "1.0.4",
@@ -6192,19 +6077,11 @@
 				}
 			}
 		},
-		"expo-random": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/expo-random/-/expo-random-11.1.2.tgz",
-			"integrity": "sha512-JaNqoYwFWJnyRSsMPpFjjSsm09wrEv+Uoif6IExfR8v6K3m/tIySoVjzS47tD6YVdxLtL/I8RmqmB6Nwh1p6AQ==",
-			"optional": true,
-			"requires": {
-				"base64-js": "^1.3.0"
-			}
-		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -6331,6 +6208,11 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
@@ -6511,9 +6393,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-			"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -6531,6 +6413,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -6538,9 +6421,9 @@
 			}
 		},
 		"formidable": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+			"integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -6622,8 +6505,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
@@ -6647,7 +6529,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
 			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -6657,8 +6538,7 @@
 				"has-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
 				}
 			}
 		},
@@ -6694,21 +6574,6 @@
 				"file-uri-to-path": "2",
 				"fs-extra": "^8.1.0",
 				"ftp": "^0.3.10"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"get-value": {
@@ -6828,7 +6693,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -6937,6 +6801,7 @@
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
 			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.4",
@@ -6953,21 +6818,6 @@
 				"@tootallnate/once": "1",
 				"agent-base": "6",
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"http-signature": {
@@ -6982,27 +6832,12 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"human-signals": {
@@ -7026,6 +6861,11 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -7177,6 +7017,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -7483,7 +7324,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -7496,24 +7338,6 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"isomorphic-webcrypto": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.8.tgz",
-			"integrity": "sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.0.22",
-				"@unimodules/core": "*",
-				"@unimodules/react-native-adapter": "*",
-				"asmcrypto.js": "^0.22.0",
-				"b64-lite": "^1.3.1",
-				"b64u-lite": "^1.0.1",
-				"expo-random": "*",
-				"msrcrypto": "^1.5.6",
-				"react-native-securerandom": "^0.1.1",
-				"str2buf": "^1.3.0",
-				"webcrypto-shim": "^0.1.4"
-			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -9509,7 +9333,8 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.14.1",
@@ -9715,13 +9540,13 @@
 			"dev": true
 		},
 		"kinvey-js-sdk": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.0.tgz",
-			"integrity": "sha512-l7J4DRU6k1UJNgpy+8wXEUP4RrpbJuBy9cMhEadrDi4xHfvXO+1rLlhupw6IXGxukOVrZCzEHzrpeMhdcMa1mg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
+			"integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
 			"requires": {
 				"events": "3.0.0",
 				"js-base64": "2.5.1",
-				"lodash": "4.17.15",
+				"lodash": "4.17.21",
 				"loglevel": "1.6.3",
 				"loglevel-plugin-prefix": "0.8.4",
 				"p-queue": "~6.1.0",
@@ -9732,11 +9557,6 @@
 				"url-join": "4.0.1"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
 				"tslib": {
 					"version": "1.10.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -10042,6 +9862,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -10057,11 +9878,11 @@
 			}
 		},
 		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
-				"yallist": "^3.0.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-dir": {
@@ -11482,7 +11303,8 @@
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -11564,11 +11386,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"msrcrypto": {
-			"version": "1.5.8",
-			"resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
-			"integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -11830,8 +11647,7 @@
 		"object-inspect": {
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
-			"dev": true
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -12173,9 +11989,9 @@
 			"dev": true
 		},
 		"pac-proxy-agent": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz",
-			"integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
 			"requires": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -12183,32 +11999,17 @@
 				"get-uri": "3",
 				"http-proxy-agent": "^4.0.1",
 				"https-proxy-agent": "5",
-				"pac-resolver": "^4.1.0",
+				"pac-resolver": "^5.0.0",
 				"raw-body": "^2.2.0",
 				"socks-proxy-agent": "5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"pac-resolver": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.2.0.tgz",
-			"integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+			"integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
 			"requires": {
-				"degenerator": "^2.2.0",
+				"degenerator": "^3.0.1",
 				"ip": "^1.1.5",
 				"netmask": "^2.0.1"
 			}
@@ -12438,7 +12239,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -12477,32 +12279,32 @@
 			}
 		},
 		"proxy-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-4.0.1.tgz",
-			"integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
 			"requires": {
 				"agent-base": "^6.0.0",
 				"debug": "4",
 				"http-proxy-agent": "^4.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^4.1.0",
+				"pac-proxy-agent": "^5.0.0",
 				"proxy-from-env": "^1.0.0",
 				"socks-proxy-agent": "^5.0.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"requires": {
-						"ms": "2.1.2"
+						"yallist": "^3.0.2"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 				}
 			}
 		},
@@ -12518,18 +12320,19 @@
 			"dev": true
 		},
 		"pubnub": {
-			"version": "4.32.1",
-			"resolved": "https://registry.npmjs.org/pubnub/-/pubnub-4.32.1.tgz",
-			"integrity": "sha512-hzwNmzVQD4SuGnepQt2JT5JCqgIP+laR1fqN8MVwUIclG0u7aSDcYn+0KJQceGWEpiN7GoQr6mQQ8K9TbiLz/w==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pubnub/-/pubnub-5.0.1.tgz",
+			"integrity": "sha512-V2xDmbKviFY4mjuFE4a4uM5K0niLa/0aHu8tGs1cUHEyLt7yG+4zli/LvNb5ZKpcsdN7rojbbiZNd8TZuT+gUg==",
 			"requires": {
 				"@babel/runtime": "^7.10.5",
+				"@tsconfig/node12": "^1.0.9",
 				"agentkeepalive": "^3.5.2",
+				"buffer": "^6.0.3",
 				"cbor-js": "^0.1.0",
 				"cbor-sync": "^1.0.4",
-				"isomorphic-webcrypto": "^2.3.6",
 				"lil-uuid": "^0.1.1",
-				"superagent": "^3.8.1",
-				"superagent-proxy": "^2.0.0"
+				"superagent": "^6.1.0",
+				"superagent-proxy": "^3.0.0"
 			}
 		},
 		"pump": {
@@ -12547,30 +12350,11 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 		},
-		"pvtsutils": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.7.tgz",
-			"integrity": "sha512-faOiD/XpB/cIebRzYwzYjCmYgiDd53YEBni+Mt1+8/HlrARHYBpsU2OHOt3EZ1ZhfRNxPL0dH3K/vKaMgNWVGA==",
-			"requires": {
-				"tslib": "^2.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -12590,20 +12374,52 @@
 			"dev": true
 		},
 		"raw-body": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
 			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.3",
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			},
 			"dependencies": {
 				"bytes": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+					"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+				},
+				"depd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+				},
+				"http-errors": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+					"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+					"requires": {
+						"depd": "2.0.0",
+						"inherits": "2.0.4",
+						"setprototypeof": "1.2.0",
+						"statuses": "2.0.1",
+						"toidentifier": "1.0.1"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+				},
+				"statuses": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+					"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+				},
+				"toidentifier": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+					"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
 				}
 			}
 		},
@@ -12963,15 +12779,6 @@
 			"integrity": "sha512-5kSKPvDU23uZRmzgKTsGhbwGNvB2tidu1VnInBHP53ZD0VEPSBl5fbpuTfHH98ED+Gp1SCcT2/e6bJWkIspKvg==",
 			"dev": true
 		},
-		"react-native-securerandom": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
-			"integrity": "sha1-8TBiOkEsM4sK+t7bwgTFy7i/IHA=",
-			"optional": true,
-			"requires": {
-				"base64-js": "*"
-			}
-		},
 		"react-refresh": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -13041,6 +12848,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -13557,7 +13365,8 @@
 		"setprototypeof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
@@ -13613,6 +13422,16 @@
 			"dev": true,
 			"optional": true
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
 		"sift": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
@@ -13659,9 +13478,9 @@
 			}
 		},
 		"smart-buffer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -13792,37 +13611,22 @@
 			}
 		},
 		"socks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+			"integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
 			"requires": {
 				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"smart-buffer": "^4.2.0"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
 			"requires": {
-				"agent-base": "6",
+				"agent-base": "^6.0.2",
 				"debug": "4",
 				"socks": "^2.3.3"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"source-map": {
@@ -13979,18 +13783,14 @@
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
-		},
-		"str2buf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
-			"integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
 		},
 		"stream-buffers": {
 			"version": "2.2.0",
@@ -14126,29 +13926,73 @@
 			"dev": true
 		},
 		"superagent": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-			"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+			"integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
 			"requires": {
-				"component-emitter": "^1.2.0",
-				"cookiejar": "^2.1.0",
-				"debug": "^3.1.0",
-				"extend": "^3.0.0",
-				"form-data": "^2.3.1",
-				"formidable": "^1.2.0",
-				"methods": "^1.1.1",
-				"mime": "^1.4.1",
-				"qs": "^6.5.1",
-				"readable-stream": "^2.3.5"
+				"component-emitter": "^1.3.0",
+				"cookiejar": "^2.1.2",
+				"debug": "^4.1.1",
+				"fast-safe-stringify": "^2.0.7",
+				"form-data": "^3.0.0",
+				"formidable": "^1.2.2",
+				"methods": "^1.1.2",
+				"mime": "^2.4.6",
+				"qs": "^6.9.4",
+				"readable-stream": "^3.6.0",
+				"semver": "^7.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+					"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"mime": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+					"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+				},
+				"qs": {
+					"version": "6.10.3",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+					"integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+					"requires": {
+						"side-channel": "^1.0.4"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"superagent-proxy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-2.1.0.tgz",
-			"integrity": "sha512-DnarpKN6Xn8e3pYlFV4Yvsj9yxLY4q5FIsUe5JvN7vjzP+YCfzXv03dTkZSD2yzrSadsNYHf0IgOUJwKjX457A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-3.0.0.tgz",
+			"integrity": "sha512-wAlRInOeDFyd9pyonrkJspdRAxdLrcsZ6aSnS+8+nu4x1aXbz6FWSTT9M6Ibze+eG60szlL7JA8wEIV7bPWuyQ==",
 			"requires": {
-				"debug": "^3.1.0",
-				"proxy-agent": "^4.0.0"
+				"debug": "^4.3.2",
+				"proxy-agent": "^5.0.0"
 			}
 		},
 		"supports-color": {
@@ -14374,7 +14218,8 @@
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "4.0.0",
@@ -14787,6 +14632,27 @@
 			"integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
 			"dev": true
 		},
+		"vm2": {
+			"version": "3.9.9",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
+			"integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
+			"requires": {
+				"acorn": "^8.7.0",
+				"acorn-walk": "^8.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+				},
+				"acorn-walk": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+				}
+			}
+		},
 		"w3c-hr-time": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -14822,30 +14688,6 @@
 			"requires": {
 				"defaults": "^1.0.3"
 			}
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"webcrypto-shim": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-			"integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
 		},
 		"webidl-conversions": {
 			"version": "6.1.0",
@@ -15103,9 +14945,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "15.4.1",

--- a/packages/react-native-sdk/package-lock.json
+++ b/packages/react-native-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "kinvey-react-native-sdk",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9540,9 +9540,9 @@
 			"dev": true
 		},
 		"kinvey-js-sdk": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.1.tgz",
-			"integrity": "sha512-Y9jyusjSWRj5gedpYTHMrIzGJo0ZLxwrovNqfYorZ3PYM7mka4a/0Bf15Sp5o4zuvsES58+Zyy3XEabG5aS2sw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kinvey-js-sdk/-/kinvey-js-sdk-6.0.2.tgz",
+			"integrity": "sha512-hhL/+f3TQvW+vDBaiHIvhrAGFuWhAMf439MTdrdhZqdzHIcsHrvzAcX9TLmsvmdA5PF2iAaAkpEtJm6uKZeU4w==",
 			"requires": {
 				"events": "3.0.0",
 				"js-base64": "2.5.1",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-react-native-sdk",
   "description": "Kinvey JavaScript SDK for React Native applications.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/react-native-sdk",
   "repository": {
@@ -29,10 +29,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "axios": "0.21.1",
-    "kinvey-js-sdk": "6.0.0",
+    "axios": "0.26.1",
+    "kinvey-js-sdk": "6.0.1",
     "lodash": "4.17.21",
-    "pubnub": "4.32.1"
+    "pubnub": "5.0.1"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.15.4",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinvey-react-native-sdk",
   "description": "Kinvey JavaScript SDK for React Native applications.",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Kinvey/js-sdk/tree/master/packages/react-native-sdk",
   "repository": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "axios": "0.26.1",
-    "kinvey-js-sdk": "6.0.1",
+    "kinvey-js-sdk": "6.0.2",
     "lodash": "4.17.21",
     "pubnub": "5.0.1"
   },


### PR DESCRIPTION
I have pushed kinvey-js-sdk 6.0.1 to NPM without the latest changes. This required a bump in all dependent shims to fix the issue.
