### PR TITLE
KDEV-2482: Clear session on InvalidCredentials error

### DIFF
--- a/packages/js-sdk/src/http/request.ts
+++ b/packages/js-sdk/src/http/request.ts
@@ -2,7 +2,7 @@ import isString from 'lodash/isString';
 import PQueue from 'p-queue';
 import { Base64 } from 'js-base64';
 import { InvalidCredentialsError } from '../errors/invalidCredentials';
-import { getAppSecret} from '../kinvey';
+import { getAppSecret, getAppKey } from '../kinvey';
 import { logger } from '../log';
 import { HttpHeaders, KinveyHttpHeaders, KinveyHttpAuth } from './headers';
 import { HttpResponse } from './response';
@@ -186,7 +186,13 @@ export class KinveyHttpRequest extends HttpRequest {
       // Login with the new MIC session
       const loginRequest = new KinveyHttpRequest({
         method: HttpRequestMethod.POST,
-        auth: KinveyHttpAuth.App,
+        headers: new KinveyHttpHeaders({
+          'Content-Type': () => 'application/json',
+          Authorization: () => {
+            const credentials = Base64.encode(`${getAppKey()}:${getAppSecret()}`);
+            return `Basic ${credentials}`;
+          }
+        }),
         url: formatKinveyBaasUrl(KinveyBaasNamespace.User, '/login'),
         body: {
           _socialIdentity: {

--- a/packages/js-sdk/src/http/request.ts
+++ b/packages/js-sdk/src/http/request.ts
@@ -7,7 +7,8 @@ import { logger } from '../log';
 import { HttpHeaders, KinveyHttpHeaders, KinveyHttpAuth } from './headers';
 import { HttpResponse } from './response';
 import { send } from './http';
-import { getSession, setSession } from './session';
+import { getSession, setSession, removeSession } from './session';
+import { DataStoreCache, QueryCache, SyncCache } from '../datastore/cache';
 import { formatKinveyAuthUrl, formatKinveyBaasUrl, KinveyBaasNamespace } from './utils';
 
 const REQUEST_QUEUE = new PQueue();
@@ -207,6 +208,20 @@ export class KinveyHttpRequest extends HttpRequest {
               } catch (error) {
                 logger.error(error.message);
               }
+            }
+          } else {
+            try {
+              // TODO: Unregister from live service
+
+              // Remove the session
+              await removeSession();
+
+              // Clear cache's
+              await QueryCache.clear();
+              await SyncCache.clear();
+              await DataStoreCache.clear();
+            } catch (error) {
+              logger.error(error.message);
             }
           }
         }

--- a/packages/js-sdk/src/http/session.ts
+++ b/packages/js-sdk/src/http/session.ts
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import { ConfigKey, getConfig } from '../config';
 import { getAppKey } from '../kinvey';
 import { Entity } from '../storage';
@@ -94,4 +95,21 @@ export async function setDeviceToken(username: string, deviceToken: string): Pro
 
 export async function removeDeviceToken(username: string): Promise<boolean> {
   return getStore().remove(getDeviceTokenKey(username));
+}
+
+export async function getKinveyMICSession(): Promise<any> {
+  const session = await getSession();
+  return get(session, '_socialIdentity.kinveyAuth', null);
+}
+
+export async function setKinveyMICSession(newKinveyMICSession): Promise<boolean> {
+  const existingKinveyMICSession = await getKinveyMICSession();
+  if (!existingKinveyMICSession) {
+    return false;
+  }
+
+  const existingSession = await getSession();
+  const mergedMICSession = Object.assign({}, existingSession._socialIdentity.kinveyAuth, newKinveyMICSession);
+  existingSession._socialIdentity.kinveyAuth = mergedMICSession;
+  return setSession(existingSession);
 }

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -544,21 +544,10 @@ describe('User tests', () => {
     after(async () => Kinvey.User.logout());
 
     it('should clear the active user when an InvalidCredentials error occurs', async () => {
-      const actualActiveUser = await Kinvey.User.getActiveUser();
-      expect(actualActiveUser).to.exist;
-      let actualErr;
-      try {
-        // we call the me endpoint for the test but this applies to every authenticated request
-        await Kinvey.User.me();
-      } catch(err) {
-        actualErr = err;
-      }
-
-      expect(actualErr).to.exist;
-      expect(actualErr.name).to.equal('InvalidCredentialsError');
-
-      const actualActiveUserAfterMe = await Kinvey.User.getActiveUser();
-      expect(actualActiveUserAfterMe).to.not.exist;
+      expect(Kinvey.User.getActiveUser()).to.eventually.exist;
+      // we call the me endpoint for the test but this applies to every authenticated request
+      await expect(Kinvey.User.me()).to.be.rejectedWith('Invalid credentials. Please retry your request with correct credentials.');
+      expect(Kinvey.User.getActiveUser()).to.eventually.not.exist;
     });
   });
 

--- a/tests/integration/specs/common/users.spec.js
+++ b/tests/integration/specs/common/users.spec.js
@@ -529,7 +529,7 @@ describe('User tests', () => {
 
     before(async () => Kinvey.User.logout());
 
-    before('setup for InvalidCredentials', async () => {
+    before(async () => {
       await utilities.safelySignUpUser(utilities.randomString(), null, true, null);
       initialActiveUser = await Kinvey.User.getActiveUser();
       delete initialActiveUser.data.password;

--- a/tests/integration/specs/utils.js
+++ b/tests/integration/specs/utils.js
@@ -416,7 +416,7 @@ export async function safelySignUpUser(username, password, setAsActive, createdU
   return newUser;
 }
 
-function buildBaasUrl(path) {
+export function buildBaasUrl(path) {
   const instanceId = process.env.INSTANCE_ID;
   const isLocalhost = instanceId && instanceId.includes('localhost');
   let protocol;
@@ -447,7 +447,7 @@ export async function removeAuthenticator(user, authenticatorId) {
   return user.removeAuthenticator(authenticatorId)
 }
 
-async function makeRequest(reqOpts, expectSuccess, requestLib) {
+export async function makeRequest(reqOpts, expectSuccess, requestLib) {
   let response;
 
   if (!requestLib) {


### PR DESCRIPTION
The PR clears the active user when an InvalidCredentials error is received and MIC is not involved. Essentially, this code is present in the latest SDK version. What is different is the missing call to the logout endpoint which has no way of succeeding.