### PR TITLE
Fix refresh token overwrite

### DIFF
--- a/packages/js-sdk/src/user/user.ts
+++ b/packages/js-sdk/src/user/user.ts
@@ -130,6 +130,10 @@ export class User {
 
     // Merge _socialIdentity
     if (data._socialIdentity) {
+      this.data = await getSession();
+      if (data._socialIdentity.kinveyAuth) {
+        delete data._socialIdentity.kinveyAuth.refresh_token;
+      }
       data._socialIdentity = mergeSocialIdentity(this._socialIdentity, data._socialIdentity);
     }
 

--- a/packages/js-sdk/test/mic/session-management.test.ts
+++ b/packages/js-sdk/test/mic/session-management.test.ts
@@ -41,6 +41,8 @@ describe('Session management', () => {
   });
 
   beforeEach(async () => {
+    this.refreshToken = getRandomStr('refreshToken');
+    this.accessToken = getRandomStr('accessToken');
     this.session = {
       _kmd: {
         authtoken: getRandomStr('authtoken')
@@ -48,8 +50,8 @@ describe('Session management', () => {
       _socialIdentity: {
         kinveyAuth: {
           identity: 'kinveyAuth',
-          access_token: getRandomStr('accessToken'),
-          refresh_token: getRandomStr('refreshToken'),
+          access_token: this.accessToken,
+          refresh_token: this.refreshToken,
           client_id: getRandomStr('clientId'),
           redirect_uri: getRandomStr('redirectURI'),
         }
@@ -169,4 +171,39 @@ describe('Session management', () => {
       expect(session).to.have.nested.property('_socialIdentity.kinveyAuth.refresh_token', this.newRefreshToken)
     });
   });
+
+  describe('when session has not expired', () => {
+    it('calling _me endpoint should not overwrite locally stored refresh_token', async () => {
+      const newAuthToken = getRandomStr('newAuthtoken')
+      const newAccessToken = getRandomStr('newAccessToken');
+      const newRefreshToken = getRandomStr('newRefreshToken');
+
+      nock(this.kcsURL)
+        .get(`/user/${this.appKey}/_me`)
+        .times(1)
+        .reply(200, {
+          _kmd: {
+            authtoken: newAuthToken
+          },
+          _socialIdentity: {
+            kinveyAuth: {
+              identity: 'kinveyAuth',
+              access_token: newAccessToken,
+              refresh_token: newRefreshToken
+            }
+          }
+        });
+
+      const activeUser = await Kinvey.User.getActiveUser();
+      expect(activeUser).to.be.an('object');
+
+      await activeUser.me();
+
+      const sessionStr = await sessionStore.get(`${this.appKey}.active_user`);
+      const session = JSON.parse(sessionStr);
+      expect(session).to.have.nested.property('_socialIdentity.kinveyAuth.access_token', newAccessToken)
+      expect(session).to.have.nested.property('_socialIdentity.kinveyAuth.refresh_token', this.refreshToken)
+    });
+
+  })
 });


### PR DESCRIPTION
Calling _me endpoint returns the last issued refresh_token as a response,
which might be issued to another device.
Therefore, we should not persist the returned refresh_token from_me endpoint locally on the device.